### PR TITLE
로그 검색 및 스크롤 fade 효과 추가

### DIFF
--- a/.changeset/log-search-fade.md
+++ b/.changeset/log-search-fade.md
@@ -1,0 +1,5 @@
+---
+"lynx-console": minor
+---
+
+로그 검색 및 스크롤 fade 효과 추가

--- a/package/src/components/ConsolePanel.css.ts
+++ b/package/src/components/ConsolePanel.css.ts
@@ -33,11 +33,14 @@ export const logHeader = style({
   flexDirection: "row",
   alignItems: "center",
   justifyContent: "space-between",
-  marginBottom: 8,
-  paddingBottom: 4,
-  borderBottomWidth: 1,
-  borderBottomColor: vars.$color.stroke.neutralSubtle,
-  borderBottomStyle: "solid",
+  paddingBottom: 3,
+});
+
+export const fadeTop = style({
+  height: 20,
+  marginBottom: -20,
+  zIndex: 1,
+  background: `linear-gradient(to bottom, ${vars.$color.bg.layerDefault}, #ffffff00)`,
 });
 
 export const filterWrapper = style({
@@ -48,7 +51,7 @@ export const filterButton = style({
   display: "flex",
   flexDirection: "row",
   alignItems: "center",
-  padding: "6px 12px",
+  padding: "3px 6px",
   backgroundColor: vars.$color.bg.neutralWeak,
   borderRadius: 4,
 });
@@ -110,8 +113,33 @@ export const filterLabel = recipe({
   },
 });
 
+export const searchWrapper = style({
+  display: "flex",
+  flexDirection: "row",
+  alignItems: "center",
+  flex: 1,
+  marginLeft: 8,
+  marginRight: 8,
+  borderBottomWidth: 1,
+  borderBottomColor: vars.$color.stroke.neutralSubtle,
+  borderBottomStyle: "solid",
+  gap: 8,
+});
+
+export const searchPrompt = style({
+  ...typography("t6", "medium"),
+  color: vars.$color.fg.placeholder,
+});
+
+export const searchInput = style({
+  flex: 1,
+  ...typography("t3", "regular"),
+  color: vars.$color.fg.neutral,
+  caretColor: vars.$color.palette.green600,
+});
+
 export const clearButton = style({
-  padding: "6px 12px",
+  padding: "3px 6px",
   backgroundColor: vars.$color.bg.neutralWeak,
   borderRadius: 4,
 });
@@ -123,6 +151,8 @@ export const clearButtonText = style({
 
 export const logList = style({
   flex: 1,
+  paddingTop: 0,
+  paddingBottom: 0,
 });
 
 export const logItem = recipe({
@@ -281,22 +311,20 @@ export const argObjectJson = style({
   color: vars.$color.fg.neutral,
 });
 
+export const fadeBottom = style({
+  height: 20,
+  marginTop: -20,
+  zIndex: 1,
+  background: `linear-gradient(to top, ${vars.$color.bg.layerDefault}, #ffffff00)`,
+});
+
 export const replInputRow = style({
   display: "flex",
   flexDirection: "row",
   alignItems: "center",
   gap: 8,
-  paddingTop: 8,
+  paddingTop: 0,
   paddingBottom: 8,
-  marginTop: -1,
-  borderTopWidth: 1,
-  borderTopColor: vars.$color.stroke.neutralSubtle,
-  borderTopStyle: "solid",
-  backgroundImage: `linear-gradient(to bottom, transparent, ${vars.$color.bg.layerDefault})`,
-  backgroundSize: "100% 32px",
-  backgroundRepeat: "no-repeat",
-  backgroundPosition: "top",
-  backgroundColor: vars.$color.bg.layerDefault,
 });
 
 export const replPrompt = style({

--- a/package/src/components/LogPanel.tsx
+++ b/package/src/components/LogPanel.tsx
@@ -1,12 +1,14 @@
-import { useEffect, useRef, useState } from "@lynx-js/react";
+import { useEffect, useMemo, useRef, useState } from "@lynx-js/react";
 import type { BaseEvent, InputInputEvent, NodesRef } from "@lynx-js/types";
 import { stringify } from "javascript-stringify";
 import type { LogEntry, LogLevel } from "../types";
+import { vars } from "../styles/vars";
 import * as css from "./ConsolePanel.css";
 
 const LOG_LEVELS: LogLevel[] = ["log", "info", "warn", "error"];
 
 let savedEnabledLevels: Set<LogLevel> | null = null;
+let savedSearchQuery = "";
 let closeFilterDropdown: (() => void) | null = null;
 
 export const dismissFilterDropdown = () => closeFilterDropdown?.();
@@ -37,7 +39,11 @@ export const LogPanel = ({ logs, clearLogs }: LogPanelProps) => {
     () => savedEnabledLevels ?? new Set(LOG_LEVELS),
   );
   const [filterOpen, setFilterOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState(savedSearchQuery);
+  const [fadeState, setFadeState] = useState({ atTop: true, atBottom: true });
+  const fadeRef = useRef({ atTop: true, atBottom: true });
   const inputRef = useRef<NodesRef>(null);
+  const searchInputRef = useRef<NodesRef>(null);
   const listRef = useRef<NodesRef>(null);
 
   useEffect(() => {
@@ -45,11 +51,34 @@ export const LogPanel = ({ logs, clearLogs }: LogPanelProps) => {
   }, [enabledLevels]);
 
   useEffect(() => {
+    savedSearchQuery = searchQuery;
+  }, [searchQuery]);
+
+  useEffect(() => {
+    if (savedSearchQuery) {
+      searchInputRef.current
+        ?.invoke({ method: "setValue", params: { value: savedSearchQuery } })
+        .exec();
+    }
+  }, []);
+
+  useEffect(() => {
     closeFilterDropdown = () => setFilterOpen(false);
     return () => { closeFilterDropdown = null; };
   }, []);
 
-  const filteredLogs = logs.filter((log) => enabledLevels.has(log.level));
+  const filteredLogs = useMemo(
+    () =>
+      logs.filter((log) => {
+        if (!enabledLevels.has(log.level)) return false;
+        if (searchQuery) {
+          const query = searchQuery.toLowerCase();
+          return log.args.some((arg) => String(arg).toLowerCase().includes(query));
+        }
+        return true;
+      }),
+    [logs, enabledLevels, searchQuery],
+  );
   const logsRef = useRef(filteredLogs);
   logsRef.current = filteredLogs;
 
@@ -209,7 +238,7 @@ export const LogPanel = ({ logs, clearLogs }: LogPanelProps) => {
             className={css.filterButton}
             catchtap={() => setFilterOpen((v) => !v)}
           >
-            <text className={css.filterButtonText}>Filter   ▼</text>
+            <text className={css.filterButtonText}>Filter  ▼</text>
           </view>
           {filterOpen && (
             <view className={css.filterDropdown} catchtap={() => {}}>
@@ -230,17 +259,48 @@ export const LogPanel = ({ logs, clearLogs }: LogPanelProps) => {
             </view>
           )}
         </view>
+        <view className={css.searchWrapper}>
+          <text className={css.searchPrompt}>{"›"}</text>
+          <input
+            ref={searchInputRef}
+            className={css.searchInput}
+            placeholder="Search logs..."
+            bindinput={(e: BaseEvent<"bindinput", InputInputEvent>) =>
+              setSearchQuery(e.detail.value)
+            }
+          />
+        </view>
         <view style={{ display: "flex", flexDirection: "row", gap: 8 }}>
           <view className={css.clearButton} bindtap={clearLogs}>
             <text className={css.clearButtonText}>Clear</text>
           </view>
         </view>
       </view>
+      <view
+        className={css.fadeTop}
+        style={{
+          background: fadeState.atTop
+            ? `linear-gradient(to bottom, #ffffff00, #ffffff00)`
+            : `linear-gradient(to bottom, ${vars.$color.bg.layerDefault}, #ffffff00)`,
+        }}
+      />
       <list
         ref={listRef}
         scroll-orientation="vertical"
         className={css.logList}
+        preload-buffer-count={10}
         initial-scroll-index={Math.max(0, filteredLogs.length - 1)}
+        scroll-event-throttle={16}
+        bindscroll={(e: BaseEvent<"bindscroll", { scrollTop: number; scrollHeight: number; listHeight: number }>) => {
+          const { scrollTop, scrollHeight, listHeight } = e.detail;
+          const atTop = scrollTop <= 10;
+          const atBottom = scrollTop + listHeight >= scrollHeight - 10;
+          if (atTop !== fadeRef.current.atTop || atBottom !== fadeRef.current.atBottom) {
+            fadeRef.current.atTop = atTop;
+            fadeRef.current.atBottom = atBottom;
+            setFadeState({ atTop, atBottom });
+          }
+        }}
       >
         {filteredLogs.length === 0 ? (
           <list-item item-key="empty-state">
@@ -283,6 +343,14 @@ export const LogPanel = ({ logs, clearLogs }: LogPanelProps) => {
           })
         )}
       </list>
+      <view
+        className={css.fadeBottom}
+        style={{
+          background: fadeState.atBottom
+            ? `linear-gradient(to top, #ffffff00, #ffffff00)`
+            : `linear-gradient(to top, ${vars.$color.bg.layerDefault}, #ffffff00)`,
+        }}
+      />
       <view className={css.replInputRow}>
         <text className={css.replPrompt}>{"›"}</text>
         <input


### PR DESCRIPTION
- 필터 옆에 로그 검색 input 추가 (검색어 상태 유지)
- 로그 리스트 상하단에 gradient fade 효과 추가 (스크롤 위치 기반 표시/숨김)
- filter/clear 버튼 패딩 축소 및 헤더/REPL 영역 border 제거

https://github.com/user-attachments/assets/f078bab7-da5d-46e4-9366-eebd2e4e72a9

