### PR TITLE
fix: list 위에서 FloatingButton 드래그 시 스크롤 방지

### DIFF
--- a/.changeset/fix-drag-list-scroll.md
+++ b/.changeset/fix-drag-list-scroll.md
@@ -1,0 +1,5 @@
+---
+"lynx-console": patch
+---
+
+fix: list 위에서 FloatingButton 드래그 시 스크롤이 같이 되는 문제 수정

--- a/example/src/App.css.ts
+++ b/example/src/App.css.ts
@@ -3,18 +3,18 @@ import { style } from "@vanilla-extract/css";
 export const container = style({
   width: "100%",
   height: "100%",
-  padding: "16px",
-  marginTop: 20,
-  marginBottom: 20,
-  display: "flex",
-  flexDirection: "column",
-  gap: 12,
+});
+
+export const list = style({
+  width: "100%",
+  height: "100%",
 });
 
 export const section = style({
   display: "flex",
   flexDirection: "column",
   gap: 8,
+  padding: 16,
 });
 
 export const sectionTitle = style({

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -91,52 +91,77 @@ const App = () => {
   };
   return (
     <view className={css.container}>
-      <view className={css.section}>
-        <text className={css.sectionTitle}>Console Tests</text>
-        <view bindtap={testConsoleLog} className={css.consoleButton}>
-          <text className={css.consoleButtonText}>Test Console Log</text>
-        </view>
-        <view
-          bindtap={() => {
-            throw new Error("Test Error");
-          }}
-          className={css.consoleButton}
-        >
-          <text className={css.consoleButtonText}>Test throw error</text>
-        </view>
-        <view
-          bindtap={() => {
-            console.error("Test console error");
-          }}
-          className={css.consoleButton}
-        >
-          <text className={css.consoleButtonText}>Test console error</text>
-        </view>
-        <view
-          main-thread:bindtap={testConsoleLogInMainThread}
-          className={css.consoleButton}
-        >
-          <text className={css.consoleButtonText}>
-            Test Console Log (Main Thread)
-          </text>
-        </view>
-      </view>
+      <list
+        className={css.list}
+        scroll-orientation="vertical"
+      >
+        <list-item item-key="section-console">
+          <view className={css.section}>
+            <text className={css.sectionTitle}>Console Tests</text>
+            <view bindtap={testConsoleLog} className={css.consoleButton}>
+              <text className={css.consoleButtonText}>Test Console Log</text>
+            </view>
+            <view
+              bindtap={() => {
+                throw new Error("Test Error");
+              }}
+              className={css.consoleButton}
+            >
+              <text className={css.consoleButtonText}>Test throw error</text>
+            </view>
+            <view
+              bindtap={() => {
+                console.error("Test console error");
+              }}
+              className={css.consoleButton}
+            >
+              <text className={css.consoleButtonText}>
+                Test console error
+              </text>
+            </view>
+            <view
+              main-thread:bindtap={testConsoleLogInMainThread}
+              className={css.consoleButton}
+            >
+              <text className={css.consoleButtonText}>
+                Test Console Log (Main Thread)
+              </text>
+            </view>
+          </view>
+        </list-item>
 
-      <view className={css.section}>
-        <text className={css.sectionTitle}>Network Tests</text>
-        <view bindtap={testGetRequest} className={css.getButton}>
-          <text className={css.getButtonText}>GET Request</text>
-        </view>
-        <view bindtap={testPostRequest} className={css.postButton}>
-          <text className={css.postButtonText}>POST Request</text>
-        </view>
-        <view bindtap={testPatchRequest} className={css.patchButton}>
-          <text className={css.patchButtonText}>PATCH Request</text>
-        </view>
-        <view bindtap={testDeleteRequest} className={css.deleteButton}>
-          <text className={css.deleteButtonText}>DELETE Request</text>
-        </view>
-      </view>
+        <list-item item-key="section-network">
+          <view className={css.section}>
+            <text className={css.sectionTitle}>Network Tests</text>
+            <view bindtap={testGetRequest} className={css.getButton}>
+              <text className={css.getButtonText}>GET Request</text>
+            </view>
+            <view bindtap={testPostRequest} className={css.postButton}>
+              <text className={css.postButtonText}>POST Request</text>
+            </view>
+            <view bindtap={testPatchRequest} className={css.patchButton}>
+              <text className={css.patchButtonText}>PATCH Request</text>
+            </view>
+            <view bindtap={testDeleteRequest} className={css.deleteButton}>
+              <text className={css.deleteButtonText}>DELETE Request</text>
+            </view>
+          </view>
+        </list-item>
+
+        {Array.from({ length: 20 }, (_, i) => (
+          <list-item item-key={`item-${i}`} key={`item-${i}`}>
+            <view
+              bindtap={() => console.log(`Item ${i + 1} tapped`)}
+              className={css.consoleButton}
+              style={{ margin: "4px 16px" }}
+            >
+              <text className={css.consoleButtonText}>
+                List Item {i + 1}
+              </text>
+            </view>
+          </list-item>
+        ))}
+      </list>
 
       <Suspense fallback={<text>Loading...</text>}>
         <LynxConsole safeAreaInsetBottom="0px" theme="light" />

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -16,9 +16,9 @@ initPerformanceMonitor();
 
 function AppWrapper() {
   return (
-    <view className="data-seed-color-mode__light-only">
+    <page className="data-seed-color-mode__light-only">
       <App />
-    </view>
+    </page>
   );
 }
 

--- a/package/src/components/FloatingButton.tsx
+++ b/package/src/components/FloatingButton.tsx
@@ -45,26 +45,29 @@ export const FloatingButton = ({
   const isDragging = phase === "dragging";
 
   return (
-    <view
-      className={css.wrapper}
-      style={{
-        right: `${right}px`,
-        bottom: `${bottom}px`,
-        transform: isDragging ? "scale(1.05)" : "scale(1)",
-      }}
-      {...handlers}
-    >
-      <view className={css.button}>
-        {children}
-        <view className={css.shineOverlay} style={SHINE_STYLES[phase]} />
-      </view>
+    <>
       <view
-        className={css.reloadButton}
-        catchtouchstart={() => clearTimer()}
-        bindtap={handleReload}
+        className={css.wrapper}
+        consume-slide-event={[[-180, 180]]}
+        style={{
+          right: `${right}px`,
+          bottom: `${bottom}px`,
+          transform: isDragging ? "scale(1.05)" : "scale(1)",
+        }}
+        {...handlers}
       >
-        <text className={css.reloadIcon}>{"\u21BB"}</text>
+        <view className={css.button}>
+          {children}
+          <view className={css.shineOverlay} style={SHINE_STYLES[phase]} />
+        </view>
+        <view
+          className={css.reloadButton}
+          catchtouchstart={() => clearTimer()}
+          bindtap={handleReload}
+        >
+          <text className={css.reloadIcon}>{"\u21BB"}</text>
+        </view>
       </view>
-    </view>
+    </>
   );
 };

--- a/package/src/hooks/useLongPressDrag.ts
+++ b/package/src/hooks/useLongPressDrag.ts
@@ -87,9 +87,9 @@ export function useLongPressDrag(onTap: () => void) {
     bottom: isDragging ? tempBottom : bottom,
     clearTimer,
     handlers: {
-      bindtouchstart: handleTouchStart,
-      bindtouchmove: handleTouchMove,
-      bindtouchend: handleTouchEnd,
+      catchtouchstart: handleTouchStart,
+      catchtouchmove: handleTouchMove,
+      catchtouchend: handleTouchEnd,
     },
   };
 }


### PR DESCRIPTION
## Summary
- FloatingButton을 `<list>` 위에서 꾹 눌러 드래그할 때 list 스크롤이 같이 되는 문제 수정
- `consume-slide-event={[[-180, 180]]}` 으로 platform-level 스크롤 제스처를 차단하여 해결
- touch handler를 `bind` → `catch` prefix로 변경하여 Lynx 이벤트 전파도 방지
- example 앱을 `<list>` + `<list-item>` 구조로 변경하여 스크롤 환경에서 테스트 가능하도록 구성

## 변경 내용

### package
- `FloatingButton.tsx`: wrapper에 `consume-slide-event={[[-180, 180]]}` 추가
- `useLongPressDrag.ts`: `bindtouch*` → `catchtouch*`로 변경

### example
- `index.tsx`: 루트 `<view>` → `<page>`로 변경
- `App.tsx`: 기존 버튼들을 `<list>` > `<list-item>` 구조로 변경 + 더미 아이템 20개 추가

## 해결 원리
Lynx의 `<list>` 스크롤은 platform-level gesture recognizer가 처리합니다. `consume-slide-event`는 해당 노드가 이벤트 응답 체인에 있을 때 지정된 각도 범위의 platform-level 스와이프 제스처를 차단합니다. `[[-180, 180]]`으로 전 방향을 차단하여 FloatingButton 터치 시 list 스크롤이 발생하지 않도록 합니다.

## Test
- [x] FloatingButton을 꾹 눌러 드래그할 때 아래 list가 스크롤되지 않는지 확인
- [x] 드래그 종료 후 list 스크롤이 정상 동작하는지 확인
- [x] FloatingButton 탭(짧은 터치)이 정상 동작하는지 확인
- [x] reload 버튼 탭이 정상 동작하는지 확인