### PR TITLE
패널 UI 스타일 통일 및 개선

### DIFF
--- a/.changeset/panel-btn-style.md
+++ b/.changeset/panel-btn-style.md
@@ -1,0 +1,10 @@
+---
+"lynx-console": patch
+---
+
+패널 버튼 스타일 통일 및 검색 초기화 버튼 추가
+
+- Network, Performance 패널의 Clear 버튼 사이즈를 Log 패널과 동일하게 축소
+- 버튼 글자색을 진회색(neutralMuted)으로 변경
+- Clear 텍스트를 🗑 아이콘으로 교체
+- 검색어가 있을 때만 표시되는 ✕ 버튼 추가

--- a/package/src/components/ConsolePanel.css.ts
+++ b/package/src/components/ConsolePanel.css.ts
@@ -138,6 +138,15 @@ export const searchInput = style({
   caretColor: vars.$color.palette.green600,
 });
 
+export const searchClear = style({
+  padding: "2px 4px",
+});
+
+export const searchClearText = style({
+  ...typography("t3", "medium"),
+  color: vars.$color.fg.placeholder,
+});
+
 export const clearButton = style({
   padding: "3px 6px",
   backgroundColor: vars.$color.bg.neutralWeak,

--- a/package/src/components/ConsolePanel.css.ts
+++ b/package/src/components/ConsolePanel.css.ts
@@ -36,13 +36,6 @@ export const logHeader = style({
   paddingBottom: 3,
 });
 
-export const fadeTop = style({
-  height: 20,
-  marginBottom: -20,
-  zIndex: 1,
-  background: `linear-gradient(to bottom, ${vars.$color.bg.layerDefault}, #ffffff00)`,
-});
-
 export const filterWrapper = style({
   position: "relative",
 });
@@ -66,7 +59,7 @@ export const filterDropdown = style({
   top: "100%",
   left: 0,
   marginTop: 4,
-  backgroundColor: vars.$color.bg.layerDefault,
+  backgroundColor: vars.$color.bg.layerFloating,
   borderWidth: 1,
   borderColor: vars.$color.stroke.neutralSubtle,
   borderStyle: "solid",
@@ -318,13 +311,6 @@ export const argObjectKey = style({
 export const argObjectJson = style({
   ...typography("t3", "regular"),
   color: vars.$color.fg.neutral,
-});
-
-export const fadeBottom = style({
-  height: 20,
-  marginTop: -20,
-  zIndex: 1,
-  background: `linear-gradient(to top, ${vars.$color.bg.layerDefault}, #ffffff00)`,
 });
 
 export const replInputRow = style({

--- a/package/src/components/ConsolePanel.css.ts
+++ b/package/src/components/ConsolePanel.css.ts
@@ -58,7 +58,7 @@ export const filterButton = style({
 
 export const filterButtonText = style({
   ...typography("t3", "medium"),
-  color: vars.$color.fg.neutral,
+  color: vars.$color.fg.neutralMuted,
 });
 
 export const filterDropdown = style({
@@ -146,7 +146,7 @@ export const clearButton = style({
 
 export const clearButtonText = style({
   ...typography("t3", "medium"),
-  color: vars.$color.fg.neutral,
+  color: vars.$color.fg.neutralMuted,
 });
 
 export const logList = style({

--- a/package/src/components/FadeList.css.ts
+++ b/package/src/components/FadeList.css.ts
@@ -1,0 +1,16 @@
+import { style } from "@vanilla-extract/css";
+import { vars } from "../styles/vars";
+
+export const fadeTop = style({
+  height: 20,
+  marginBottom: -20,
+  zIndex: 1,
+  background: `linear-gradient(to bottom, ${vars.$color.bg.layerFloating}, #ffffff00)`,
+});
+
+export const fadeBottom = style({
+  height: 20,
+  marginTop: -20,
+  zIndex: 1,
+  background: `linear-gradient(to top, ${vars.$color.bg.layerFloating}, #ffffff00)`,
+});

--- a/package/src/components/FadeList.tsx
+++ b/package/src/components/FadeList.tsx
@@ -1,0 +1,76 @@
+import { useRef, useState } from "@lynx-js/react";
+import type { BaseEvent, NodesRef } from "@lynx-js/types";
+import { vars } from "../styles/vars";
+import * as css from "./FadeList.css";
+
+interface FadeListProps {
+  className?: string;
+  listRef?: React.RefObject<NodesRef>;
+  children: React.ReactNode;
+  "preload-buffer-count"?: number;
+  "initial-scroll-index"?: number;
+}
+
+export const FadeList = ({
+  className,
+  listRef: externalListRef,
+  children,
+  ...listProps
+}: FadeListProps) => {
+  const [fadeState, setFadeState] = useState({ atTop: true, atBottom: true });
+  const fadeRef = useRef({ atTop: true, atBottom: true });
+  const internalListRef = useRef<NodesRef>(null);
+  const listRef = externalListRef ?? internalListRef;
+
+  return (
+    <>
+      <view
+        className={css.fadeTop}
+        style={{
+          background: fadeState.atTop
+            ? "linear-gradient(to bottom, #ffffff00, #ffffff00)"
+            : `linear-gradient(to bottom, ${vars.$color.bg.layerFloating}, #ffffff00)`,
+        }}
+      />
+      <list
+        ref={listRef}
+        scroll-orientation="vertical"
+        className={className}
+        scroll-event-throttle={16}
+        bindscroll={(
+          e: BaseEvent<
+            "bindscroll",
+            {
+              scrollTop: number;
+              scrollHeight: number;
+              listHeight: number;
+            }
+          >,
+        ) => {
+          const { scrollTop, scrollHeight, listHeight } = e.detail;
+          const atTop = scrollTop <= 10;
+          const atBottom = scrollTop + listHeight >= scrollHeight - 10;
+          if (
+            atTop !== fadeRef.current.atTop ||
+            atBottom !== fadeRef.current.atBottom
+          ) {
+            fadeRef.current.atTop = atTop;
+            fadeRef.current.atBottom = atBottom;
+            setFadeState({ atTop, atBottom });
+          }
+        }}
+        {...listProps}
+      >
+        {children}
+      </list>
+      <view
+        className={css.fadeBottom}
+        style={{
+          background: fadeState.atBottom
+            ? "linear-gradient(to top, #ffffff00, #ffffff00)"
+            : `linear-gradient(to top, ${vars.$color.bg.layerFloating}, #ffffff00)`,
+        }}
+      />
+    </>
+  );
+};

--- a/package/src/components/LogPanel.tsx
+++ b/package/src/components/LogPanel.tsx
@@ -269,10 +269,23 @@ export const LogPanel = ({ logs, clearLogs }: LogPanelProps) => {
               setSearchQuery(e.detail.value)
             }
           />
+          {searchQuery.length > 0 && (
+            <view
+              className={css.searchClear}
+              bindtap={() => {
+                setSearchQuery("");
+                searchInputRef.current
+                  ?.invoke({ method: "setValue", params: { value: "" } })
+                  .exec();
+              }}
+            >
+              <text className={css.searchClearText}>✕</text>
+            </view>
+          )}
         </view>
         <view style={{ display: "flex", flexDirection: "row", gap: 8 }}>
           <view className={css.clearButton} bindtap={clearLogs}>
-            <text className={css.clearButtonText}>Clear</text>
+            <text className={css.clearButtonText}>🗑</text>
           </view>
         </view>
       </view>

--- a/package/src/components/LogPanel.tsx
+++ b/package/src/components/LogPanel.tsx
@@ -2,8 +2,8 @@ import { useEffect, useMemo, useRef, useState } from "@lynx-js/react";
 import type { BaseEvent, InputInputEvent, NodesRef } from "@lynx-js/types";
 import { stringify } from "javascript-stringify";
 import type { LogEntry, LogLevel } from "../types";
-import { vars } from "../styles/vars";
 import * as css from "./ConsolePanel.css";
+import { FadeList } from "./FadeList";
 
 const LOG_LEVELS: LogLevel[] = ["log", "info", "warn", "error"];
 
@@ -40,8 +40,6 @@ export const LogPanel = ({ logs, clearLogs }: LogPanelProps) => {
   );
   const [filterOpen, setFilterOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState(savedSearchQuery);
-  const [fadeState, setFadeState] = useState({ atTop: true, atBottom: true });
-  const fadeRef = useRef({ atTop: true, atBottom: true });
   const inputRef = useRef<NodesRef>(null);
   const searchInputRef = useRef<NodesRef>(null);
   const listRef = useRef<NodesRef>(null);
@@ -289,31 +287,11 @@ export const LogPanel = ({ logs, clearLogs }: LogPanelProps) => {
           </view>
         </view>
       </view>
-      <view
-        className={css.fadeTop}
-        style={{
-          background: fadeState.atTop
-            ? `linear-gradient(to bottom, #ffffff00, #ffffff00)`
-            : `linear-gradient(to bottom, ${vars.$color.bg.layerDefault}, #ffffff00)`,
-        }}
-      />
-      <list
-        ref={listRef}
-        scroll-orientation="vertical"
+      <FadeList
+        listRef={listRef}
         className={css.logList}
         preload-buffer-count={10}
         initial-scroll-index={Math.max(0, filteredLogs.length - 1)}
-        scroll-event-throttle={16}
-        bindscroll={(e: BaseEvent<"bindscroll", { scrollTop: number; scrollHeight: number; listHeight: number }>) => {
-          const { scrollTop, scrollHeight, listHeight } = e.detail;
-          const atTop = scrollTop <= 10;
-          const atBottom = scrollTop + listHeight >= scrollHeight - 10;
-          if (atTop !== fadeRef.current.atTop || atBottom !== fadeRef.current.atBottom) {
-            fadeRef.current.atTop = atTop;
-            fadeRef.current.atBottom = atBottom;
-            setFadeState({ atTop, atBottom });
-          }
-        }}
       >
         {filteredLogs.length === 0 ? (
           <list-item item-key="empty-state">
@@ -355,15 +333,7 @@ export const LogPanel = ({ logs, clearLogs }: LogPanelProps) => {
             );
           })
         )}
-      </list>
-      <view
-        className={css.fadeBottom}
-        style={{
-          background: fadeState.atBottom
-            ? `linear-gradient(to top, #ffffff00, #ffffff00)`
-            : `linear-gradient(to top, ${vars.$color.bg.layerDefault}, #ffffff00)`,
-        }}
-      />
+      </FadeList>
       <view className={css.replInputRow}>
         <text className={css.replPrompt}>{"›"}</text>
         <input

--- a/package/src/components/NetworkPanel.css.ts
+++ b/package/src/components/NetworkPanel.css.ts
@@ -17,9 +17,6 @@ export const header = style({
   justifyContent: "space-between",
   marginBottom: 8,
   paddingBottom: 4,
-  borderBottomWidth: 1,
-  borderBottomColor: vars.$color.stroke.neutralSubtle,
-  borderBottomStyle: "solid",
 });
 
 export const count = style({

--- a/package/src/components/NetworkPanel.css.ts
+++ b/package/src/components/NetworkPanel.css.ts
@@ -28,14 +28,14 @@ export const count = style({
 });
 
 export const clearButton = style({
-  padding: "6px 12px",
+  padding: "3px 6px",
   backgroundColor: vars.$color.bg.neutralWeak,
   borderRadius: 4,
 });
 
 export const clearButtonText = style({
   ...typography("t3", "medium"),
-  color: vars.$color.fg.neutral,
+  color: vars.$color.fg.neutralMuted,
 });
 
 export const list = style({

--- a/package/src/components/NetworkPanel.tsx
+++ b/package/src/components/NetworkPanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from "@lynx-js/react";
 import type { NetworkEntry } from "../types";
+import { FadeList } from "./FadeList";
 import { NetworkDetailSection } from "./NetworkDetailSection";
 import * as css from "./NetworkPanel.css";
 
@@ -16,7 +17,6 @@ export const NetworkPanel = ({
 }: NetworkPanelProps) => {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<TabType>("general");
-
   const formatDuration = (duration?: number): string => {
     if (!duration) return "-";
     if (duration < 1000) return `${duration}ms`;
@@ -80,7 +80,7 @@ export const NetworkPanel = ({
           <text className={css.placeholderText}>No network requests yet</text>
         </view>
       ) : (
-        <list className={css.list}>
+        <FadeList className={css.list}>
           {networks.map((network) => (
             <list-item key={network.id} item-key={network.id}>
               <view className={css.item({ status: network.status })}>
@@ -215,7 +215,7 @@ export const NetworkPanel = ({
               </view>
             </list-item>
           ))}
-        </list>
+        </FadeList>
       )}
     </view>
   );

--- a/package/src/components/NetworkPanel.tsx
+++ b/package/src/components/NetworkPanel.tsx
@@ -71,7 +71,7 @@ export const NetworkPanel = ({
       <view className={css.header}>
         <text className={css.count}>Total: {networks.length} requests</text>
         <view className={css.clearButton} bindtap={clearNetworks}>
-          <text className={css.clearButtonText}>Clear</text>
+          <text className={css.clearButtonText}>🗑</text>
         </view>
       </view>
 

--- a/package/src/components/PerformancePanel.css.ts
+++ b/package/src/components/PerformancePanel.css.ts
@@ -28,14 +28,14 @@ export const count = style({
 });
 
 export const clearButton = style({
-  padding: "6px 12px",
+  padding: "3px 6px",
   backgroundColor: vars.$color.bg.neutralWeak,
   borderRadius: 4,
 });
 
 export const clearButtonText = style({
   ...typography("t3", "medium"),
-  color: vars.$color.fg.neutral,
+  color: vars.$color.fg.neutralMuted,
 });
 
 export const list = style({

--- a/package/src/components/PerformancePanel.tsx
+++ b/package/src/components/PerformancePanel.tsx
@@ -1,6 +1,7 @@
 import { useState } from "@lynx-js/react";
 import { stringify } from "javascript-stringify";
 import type { PerformanceEntryData } from "../types";
+import { FadeList } from "./FadeList";
 import * as css from "./PerformancePanel.css";
 
 interface PerformancePanelProps {
@@ -65,7 +66,6 @@ export const PerformancePanel = ({
   clearPerformances,
 }: PerformancePanelProps) => {
   const [selectedId, setSelectedId] = useState<string | null>(null);
-
   if (performances.length === 0) {
     return (
       <view className={css.container}>
@@ -101,7 +101,7 @@ export const PerformancePanel = ({
         </view>
       </view>
 
-      <list className={css.list}>
+      <FadeList className={css.list}>
         {performances.map((perf) => {
           const isMetricFcp = isMetricFcpEntry(perf);
           const fcpMetrics = extractFcpMetrics(perf);
@@ -203,7 +203,7 @@ export const PerformancePanel = ({
             </list-item>
           );
         })}
-      </list>
+      </FadeList>
     </view>
   );
 };

--- a/package/src/components/PerformancePanel.tsx
+++ b/package/src/components/PerformancePanel.tsx
@@ -80,7 +80,7 @@ export const PerformancePanel = ({
             <text>Log</text>
           </view>
           <view bindtap={clearPerformances} className={css.clearButton}>
-            <text className={css.clearButtonText}>Clear</text>
+            <text className={css.clearButtonText}>🗑</text>
           </view>
         </view>
         <view className={css.placeholder}>
@@ -97,7 +97,7 @@ export const PerformancePanel = ({
       <view className={css.header}>
         <text className={css.count}>{performances.length} entries</text>
         <view bindtap={clearPerformances} className={css.clearButton}>
-          <text className={css.clearButtonText}>Clear</text>
+          <text className={css.clearButtonText}>🗑</text>
         </view>
       </view>
 


### PR DESCRIPTION
- Network, Performance 패널의 Clear 버튼 사이즈를 Log 패널과 동일하게 축소 (padding 6px 12px → 3px 6px)
- 세 패널 버튼 글자색을 fg.neutral → fg.neutralMuted(진회색)로 변경
- Clear 텍스트를 🗑 아이콘으로 교체
- Log 패널 검색 input에 검색어 초기화 ✕ 버튼 추가 (검색어 있을 때만 표시)
- 스크롤 fade 효과를 FadeList 공통 컴포넌트로 분리하여 세 패널에 적용
- fade gradient 색상을 layerDefault → layerFloating으로 변경
- Network 패널 헤더 border bottom 제거]