### PR TITLE
fix: global.css import 누락으로 인한 색상 미적용 수정

### DIFF
--- a/.changeset/fix-global-css-import.md
+++ b/.changeset/fix-global-css-import.md
@@ -1,0 +1,5 @@
+---
+"lynx-console": patch
+---
+
+fix: global.css import 누락으로 인한 색상 미적용 문제 수정

--- a/package/src/index.tsx
+++ b/package/src/index.tsx
@@ -1,4 +1,5 @@
 import "./styles/vars/index.css";
+import "./styles/global.css";
 import {
   type ForwardedRef,
   forwardRef,


### PR DESCRIPTION
vanilla-extract 제거 시 global.css의 명시적 import가 누락되어
page 배경색과 text 색상이 적용되지 않던 문제 수정