### PR TITLE
fix: tsdown 빌드 설정 분리로 lazy loading CSS 누락 수정

### DIFF
--- a/.changeset/cool-sails-argue.md
+++ b/.changeset/cool-sails-argue.md
@@ -1,0 +1,8 @@
+---
+"lynx-console": patch
+---
+
+fix: tsdown 빌드 설정을 index/setup 엔트리별로 분리하여 lazy loading 시 CSS가 async chunk에 포함되도록 수정
+
+- setup.mjs에서 불필요한 CSS banner(`import "./index.css"`) 제거
+- PerformancePanel 디버그 버튼 제거

--- a/package/src/components/PerformancePanel.tsx
+++ b/package/src/components/PerformancePanel.tsx
@@ -98,14 +98,6 @@ export const PerformancePanel = ({
             0 entries
           </text>
           <view
-            bindtap={() => {
-              console.log("[PerformancePanel] performances", performances);
-            }}
-            style={{ padding: "10px", backgroundColor: "red" }}
-          >
-            <text>Log</text>
-          </view>
-          <view
             bindtap={clearPerformances}
             className={"pp-clearButton"}
             style={{ backgroundColor: colors.bg.neutralWeak }}

--- a/package/tsdown.config.ts
+++ b/package/tsdown.config.ts
@@ -1,16 +1,26 @@
 import { defineConfig } from "tsdown";
 
-export default defineConfig({
-  entry: {
-    index: "src/index.tsx",
-    setup: "src/setup/index.ts",
+export default defineConfig([
+  {
+    entry: {
+      index: "src/index.tsx",
+    },
+    format: ["cjs", "esm"],
+    dts: true,
+    clean: true,
+    inlineOnly: false,
+    outDir: "dist",
+    banner: {
+      js: 'import "./index.css";',
+    },
   },
-  format: ["cjs", "esm"],
-  dts: true,
-  clean: true,
-  inlineOnly: false,
-  outDir: "dist",
-  banner: {
-    js: 'import "./index.css";',
+  {
+    entry: {
+      setup: "src/setup/index.ts",
+    },
+    format: ["cjs", "esm"],
+    dts: true,
+    inlineOnly: false,
+    outDir: "dist",
   },
-});
+]);


### PR DESCRIPTION
setup.mjs에 불필요한 CSS banner(import "./index.css")가 포함되어 소비자 앱에서 lazy loading 시 CSS가 async chunk 대신 main chunk에 할당되는 문제를 수정합니다.

- tsdown 설정을 index/setup 엔트리별로 분리
- CSS banner를 index 엔트리에만 적용