### PR TITLE
fix: main thread에서 Map/Set 등 비-JSON 타입 로깅 시 데이터 손실 수정

### DIFF
--- a/.changeset/fix-main-thread-devalue.md
+++ b/.changeset/fix-main-thread-devalue.md
@@ -1,0 +1,5 @@
+---
+"lynx-console": patch
+---
+
+fix: main thread에서 Map/Set 등 비-JSON 타입 로깅 시 데이터 손실 수정

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -17,7 +17,14 @@ const App = () => {
 
   const testConsoleLogInMainThread = () => {
     'main thread';
-    console.log('This is a log message in main thread');
+    console.log(
+      'This is a log message in main thread',
+      {
+        data: 'test',
+      },
+      new Map([['key', 'value']]),
+      new Set([1, 2, 3]),
+    );
   };
 
   const testGetRequest = async () => {

--- a/package/package.json
+++ b/package/package.json
@@ -43,6 +43,7 @@
     "@types/react": "^18"
   },
   "dependencies": {
+    "devalue": "^5.6.4",
     "javascript-stringify": "^2.1.0"
   },
   "repository": {

--- a/package/src/setup/_setupMainThreadConsole.ts
+++ b/package/src/setup/_setupMainThreadConsole.ts
@@ -6,6 +6,7 @@ import type { LogEntry, LogLevel } from "../types";
 const _setupMainThreadConsole = (): void => {
   "main thread";
 
+  //IMPORTANT: do not use external functions in main thread
   if (!globalThis.__LYNX_CONSOLE__) globalThis.__LYNX_CONSOLE__ = {};
   const lynxConsole = globalThis.__LYNX_CONSOLE__;
 

--- a/package/src/setup/_setupMainThreadConsole.ts
+++ b/package/src/setup/_setupMainThreadConsole.ts
@@ -1,6 +1,8 @@
 import { runOnBackground } from "@lynx-js/react";
+import { stringify as devalueStringify } from "devalue" with {
+  runtime: "shared",
+};
 import { parse as devalueParse } from "devalue";
-import { stringify as devalueStringify } from "devalue" with { runtime: "shared" };
 import type { LogEntry, LogLevel } from "../types";
 
 const _setupMainThreadConsole = (): void => {
@@ -40,7 +42,9 @@ const _setupMainThreadConsole = (): void => {
     // devalue 문자열을 원래 타입으로 복원
     entry.args = entry.args.map((arg) => {
       if (typeof arg !== "string") {
-        throw new Error(`[LynxConsole] Expected devalue string, got ${typeof arg}`);
+        throw new Error(
+          `[LynxConsole] Expected devalue string, got ${typeof arg}`,
+        );
       }
       return devalueParse(arg);
     });

--- a/package/src/setup/_setupMainThreadConsole.ts
+++ b/package/src/setup/_setupMainThreadConsole.ts
@@ -1,10 +1,11 @@
 import { runOnBackground } from "@lynx-js/react";
+import { parse as devalueParse } from "devalue";
+import { stringify as devalueStringify } from "devalue" with { runtime: "shared" };
 import type { LogEntry, LogLevel } from "../types";
 
 const _setupMainThreadConsole = (): void => {
   "main thread";
 
-  //IMPORTANT: do not use external functions in main thread
   if (!globalThis.__LYNX_CONSOLE__) globalThis.__LYNX_CONSOLE__ = {};
   const lynxConsole = globalThis.__LYNX_CONSOLE__;
 
@@ -16,13 +17,12 @@ const _setupMainThreadConsole = (): void => {
   const LOG_METHODS: LogLevel[] = ["log", "warn", "error", "info"];
   const LOG_ID_PREFIX = "main-thread";
 
-  const serializeArgs = (args: unknown[]): unknown[] => {
+  const serializeArgs = (args: unknown[]): string[] => {
     return args.map((arg) => {
       try {
-        JSON.stringify(arg);
-        return arg;
+        return devalueStringify(arg);
       } catch {
-        return String(arg);
+        return devalueStringify(String(arg));
       }
     });
   };
@@ -35,6 +35,15 @@ const _setupMainThreadConsole = (): void => {
   const sendLogToBackground = runOnBackground((entry: LogEntry): void => {
     const state = globalThis.__LYNX_CONSOLE__?.state;
     if (!state) return;
+
+    // devalue 문자열을 원래 타입으로 복원
+    entry.args = entry.args.map((arg) => {
+      try {
+        return devalueParse(arg as string);
+      } catch {
+        return arg;
+      }
+    });
 
     state.logs?.push(entry);
     state.logListeners?.forEach((listener) => {

--- a/package/src/setup/_setupMainThreadConsole.ts
+++ b/package/src/setup/_setupMainThreadConsole.ts
@@ -38,11 +38,10 @@ const _setupMainThreadConsole = (): void => {
 
     // devalue 문자열을 원래 타입으로 복원
     entry.args = entry.args.map((arg) => {
-      try {
-        return devalueParse(arg as string);
-      } catch {
-        return arg;
+      if (typeof arg !== "string") {
+        throw new Error(`[LynxConsole] Expected devalue string, got ${typeof arg}`);
       }
+      return devalueParse(arg);
     });
 
     state.logs?.push(entry);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2936,6 +2936,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"devalue@npm:^5.6.4":
+  version: 5.6.4
+  resolution: "devalue@npm:5.6.4"
+  checksum: 10c0/0c1bbe036945e55c5f6d54f52bb1a99b19677dd48a8404517fbddb02e725803457bed6317d2c05292d68767914ba319a6a645dbfdf8ade65d687ab430bfc2ae1
+  languageName: node
+  linkType: hard
+
 "dir-glob@npm:^3.0.1":
   version: 3.0.1
   resolution: "dir-glob@npm:3.0.1"
@@ -4358,6 +4365,7 @@ __metadata:
     "@lynx-js/react": "npm:^0.116.0"
     "@lynx-js/types": "npm:^3.7.0"
     "@types/react": "npm:^18.3.28"
+    devalue: "npm:^5.6.4"
     javascript-stringify: "npm:^2.1.0"
     react: "npm:^18.3.1"
     tsdown: "npm:^0.20.1"


### PR DESCRIPTION
## Summary
- Main thread에서 `console.log`로 `Map`, `Set`, `RegExp` 등 비-JSON 타입을 기록하면 빈 객체 `{}`로 표시되는 문제 수정
- `devalue` 라이브러리를 도입하여 main thread에서 `devalue.stringify`로 직렬화, background thread에서 `devalue.parse`로 복원

## Problem
Lynx 런타임은 스레드 간 통신에 `JSON.stringify`/`JSON.parse`를 사용합니다. `JSON.stringify(new Map(...))` → `"{}"` 으로 데이터가 손실됩니다.

## Solution
`serializeArgs`에서 모든 arg를 `devalue.stringify`로 JSON-safe 문자열로 변환하고, `sendLogToBackground` 콜백에서 `devalue.parse`로 원래 타입을 복원합니다.

## Test plan
- [ ] Main thread에서 `console.log(new Map([['key', 'value']]))` 호출 시 `Map(1)` 프리뷰와 내용이 정상 표시되는지 확인
- [ ] Main thread에서 `console.log(new Set([1, 2, 3]))` 호출 시 `Set(3)` 프리뷰와 내용이 정상 표시되는지 확인
- [ ] 기존 원시값(문자열, 숫자, 객체 등) 로깅이 정상 동작하는지 확인
- [ ] Background thread 로깅이 영향 없이 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)