### PR TITLE
fix: remove style.css export to prevent CSS double-loading

### DIFF
--- a/.changeset/remove-style-css-export.md
+++ b/.changeset/remove-style-css-export.md
@@ -1,0 +1,5 @@
+---
+"lynx-console": patch
+---
+
+Remove `./style.css` export to fix CSS breakage when using dist package in Lynx apps

--- a/package/package.json
+++ b/package/package.json
@@ -3,8 +3,7 @@
   "version": "0.3.0",
   "type": "module",
   "sideEffects": [
-    "**/*.css",
-    "dist/index.css"
+    "**/*.css"
   ],
   "exports": {
     ".": {
@@ -16,8 +15,7 @@
       "types": "./dist/setup.d.mts",
       "import": "./dist/setup.mjs",
       "require": "./dist/setup.cjs"
-    },
-    "./style.css": "./dist/index.css"
+    }
   },
   "main": "dist/index.mjs",
   "types": "dist/index.d.mts",


### PR DESCRIPTION
- 불필요한 style.css export를 제거해요
- banner의 `import "./index.css"`와 소비자의 `import 'lynx-console/style.css'`가 동일한 CSS를 이중 로딩하여 레이아웃이 깨지는 문제를 수정해요