### PR TITLE
chore: lower peerDependencies version requirements

### DIFF
--- a/.changeset/lower-peer-deps.md
+++ b/.changeset/lower-peer-deps.md
@@ -1,0 +1,5 @@
+---
+"lynx-console": patch
+---
+
+Lower peerDependencies: @lynx-js/react ^0.110.0, @lynx-js/types ^3.6.0

--- a/package/package.json
+++ b/package/package.json
@@ -36,8 +36,8 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@lynx-js/react": "^0.116.0",
-    "@lynx-js/types": "^3.7.0",
+    "@lynx-js/react": "^0.110.0",
+    "@lynx-js/types": "^3.6.0",
     "@types/react": "^18"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4371,8 +4371,8 @@ __metadata:
     tsdown: "npm:^0.20.1"
     typescript: "npm:^5.9.3"
   peerDependencies:
-    "@lynx-js/react": ^0.116.0
-    "@lynx-js/types": ^3.7.0
+    "@lynx-js/react": ^0.110.0
+    "@lynx-js/types": ^3.6.0
     "@types/react": ^18
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Allow usage with @lynx-js/react >=0.110.0 and @lynx-js/types >=3.6.0 to support a wider range of consumer projects.