### PR TITLE
fix: iOS에서 코드 실행 시 스크롤 에러 수정

### DIFF
--- a/.changeset/fix-ios-scroll-error.md
+++ b/.changeset/fix-ios-scroll-error.md
@@ -1,0 +1,5 @@
+---
+"lynx-console": patch
+---
+
+Remove duplicate scrollToBottom call that caused iOS scroll error

--- a/package/src/components/LogPanel.tsx
+++ b/package/src/components/LogPanel.tsx
@@ -182,7 +182,6 @@ export const LogPanel = ({ logs, clearLogs }: LogPanelProps) => {
       ?.invoke({ method: "setValue", params: { value: "" } })
       .exec();
     runCode(trimmed);
-    setTimeout(() => scrollToBottom(false), 100);
   };
 
   const renderArg = (


### PR DESCRIPTION
LogPanel에서 코드 실행 후 중복 scrollToBottom 호출을 제거하여 iOS 스크롤 충돌 에러를 수정