### PR TITLE
feat: console.log에서 %c 등 포맷 지정자 지원

### DIFF
--- a/.changeset/feat-console-format-specifiers.md
+++ b/.changeset/feat-console-format-specifiers.md
@@ -1,0 +1,5 @@
+---
+"lynx-console": minor
+---
+
+Support console format specifiers (`%c`, `%s`, `%d`, `%i`, `%f`, `%o`, `%O`, `%%`) in log rendering. `%c` applies inline CSS styles to subsequent text segments, mirroring Chrome DevTools behavior.

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -15,6 +15,17 @@ const App = () => {
     );
   };
 
+  const testCssConsoleLog = () => {
+    console.log(
+      '%c [Css Test] %cscreen:home/tab:feed',
+      'background: #222; color: #ff69b4; padding: 2px 4px; border-radius: 2px',
+      'color: #ff6f00; font-weight: bold',
+    );
+    console.log('mixed format: %s got %d points (%ffps)', 'alice', 42, 59.95);
+    console.log('with object %o and tail', { user: 'alice', id: 1 }, 'end');
+    console.log('escaped %% percent');
+  };
+
   const testConsoleLogInMainThread = () => {
     'main thread';
     console.log(
@@ -108,6 +119,14 @@ const App = () => {
             >
               <text className="app-buttonText app-consoleButtonText">
                 Test Console Log
+              </text>
+            </view>
+            <view
+              bindtap={testCssConsoleLog}
+              className="app-baseButton app-consoleButton"
+            >
+              <text className="app-buttonText app-consoleButtonText">
+                Test CSS Console Log
               </text>
             </view>
             <view

--- a/package/src/components/LogPanel.tsx
+++ b/package/src/components/LogPanel.tsx
@@ -4,6 +4,7 @@ import { stringify } from "javascript-stringify";
 import { useThemeColors } from "../styles/ThemeContext";
 import { fontWeight, type ThemeColors } from "../styles/theme";
 import type { LogEntry, LogLevel } from "../types";
+import { parseConsoleArgs } from "../utils/parseFormat";
 import "./ConsolePanel.css";
 
 const LOG_LEVELS: LogLevel[] = ["log", "info", "warn", "error"];
@@ -536,19 +537,46 @@ export const LogPanel = ({ logs, clearLogs }: LogPanelProps) => {
                     </text>
                   </view>
                   <view className={"cp-logArgsContainer"}>
-                    {log.args.map((arg, index) => (
-                      <view
-                        key={`${log.id}-${index.toString()}`}
-                        className={"cp-logArgItem"}
-                        style={{ fontWeight: fontWeight.regular }}
-                      >
-                        {renderArg(
-                          arg,
-                          `${log.id}-${index.toString()}`,
-                          log.level,
-                        )}
-                      </view>
-                    ))}
+                    {(() => {
+                      const { segments, rest } = parseConsoleArgs(log.args);
+                      const baseTextStyle = {
+                        color: getStringColor(colors, log.level),
+                        fontWeight: fontWeight.regular,
+                      };
+                      const wrap = (key: string, content: React.ReactNode) => (
+                        <view
+                          key={key}
+                          className={"cp-logArgItem"}
+                          style={{ fontWeight: fontWeight.regular }}
+                        >
+                          {content}
+                        </view>
+                      );
+                      return (
+                        <>
+                          {segments.map((seg, index) => {
+                            const key = `${log.id}-seg-${index.toString()}`;
+                            return wrap(
+                              key,
+                              seg.type === "text" ? (
+                                <text
+                                  className={"cp-argString t3"}
+                                  style={{ ...baseTextStyle, ...seg.style }}
+                                >
+                                  {seg.text}
+                                </text>
+                              ) : (
+                                renderArg(seg.value, key, log.level)
+                              ),
+                            );
+                          })}
+                          {rest.map((arg, index) => {
+                            const key = `${log.id}-rest-${index.toString()}`;
+                            return wrap(key, renderArg(arg, key, log.level));
+                          })}
+                        </>
+                      );
+                    })()}
                   </view>
                 </view>
               </list-item>

--- a/package/src/utils/parseCssStyle.ts
+++ b/package/src/utils/parseCssStyle.ts
@@ -1,0 +1,24 @@
+export type StyleObject = Record<string, string>;
+
+const DANGEROUS_VALUE = /url\s*\(|expression\s*\(|@import/i;
+
+const toCamelCase = (name: string): string => {
+  if (name.startsWith("--")) return name;
+  return name.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+};
+
+export const parseCssString = (css: string): StyleObject => {
+  const result: StyleObject = {};
+  for (const raw of css.split(";")) {
+    const decl = raw.trim();
+    if (!decl) continue;
+    const colon = decl.indexOf(":");
+    if (colon <= 0) continue;
+    const name = decl.slice(0, colon).trim().toLowerCase();
+    const value = decl.slice(colon + 1).trim();
+    if (!name || !value) continue;
+    if (DANGEROUS_VALUE.test(value)) continue;
+    result[toCamelCase(name)] = value;
+  }
+  return result;
+};

--- a/package/src/utils/parseFormat.ts
+++ b/package/src/utils/parseFormat.ts
@@ -1,0 +1,90 @@
+import { parseCssString, type StyleObject } from "./parseCssStyle";
+
+export type LogSegment =
+  | { type: "text"; text: string; style?: StyleObject }
+  | { type: "arg"; value: unknown };
+
+export interface ParsedLogArgs {
+  segments: LogSegment[];
+  rest: unknown[];
+}
+
+const HAS_FORMAT = /%[csdifoO%]/;
+
+const formatNumber = (v: unknown, int: boolean): string => {
+  const n =
+    typeof v === "number"
+      ? int
+        ? Math.trunc(v)
+        : v
+      : typeof v === "symbol"
+        ? Number.NaN
+        : int
+          ? parseInt(String(v), 10)
+          : parseFloat(String(v));
+  return Number.isNaN(n) ? "NaN" : String(n);
+};
+
+export const parseConsoleArgs = (args: unknown[]): ParsedLogArgs => {
+  const first = args[0];
+  if (typeof first !== "string" || !HAS_FORMAT.test(first)) {
+    return { segments: [], rest: args };
+  }
+
+  const segments: LogSegment[] = [];
+  let currentText = "";
+  let currentStyle: StyleObject | undefined;
+  let argIndex = 1;
+  let lastIndex = 0;
+
+  const flushText = () => {
+    if (currentText) {
+      segments.push({ type: "text", text: currentText, style: currentStyle });
+      currentText = "";
+    }
+  };
+
+  const re = /%([csdifoO%])/g;
+  let match: RegExpExecArray | null = re.exec(first);
+  while (match !== null) {
+    currentText += first.slice(lastIndex, match.index);
+    lastIndex = re.lastIndex;
+    const spec = match[1];
+
+    if (spec === "%") {
+      currentText += "%";
+    } else if (argIndex >= args.length) {
+      currentText += match[0];
+    } else {
+      const arg = args[argIndex++];
+      switch (spec) {
+        case "c":
+          flushText();
+          currentStyle =
+            typeof arg === "string" ? parseCssString(arg) : undefined;
+          break;
+        case "s":
+          currentText += String(arg);
+          break;
+        case "d":
+        case "i":
+          currentText += formatNumber(arg, true);
+          break;
+        case "f":
+          currentText += formatNumber(arg, false);
+          break;
+        case "o":
+        case "O":
+          flushText();
+          segments.push({ type: "arg", value: arg });
+          break;
+      }
+    }
+
+    match = re.exec(first);
+  }
+  currentText += first.slice(lastIndex);
+  flushText();
+
+  return { segments, rest: args.slice(argIndex) };
+};


### PR DESCRIPTION
## Summary

- 브라우저 DevTools처럼 `console.log`의 포맷 지정자(`%c`, `%s`, `%d`, `%i`, `%f`, `%o`, `%O`, `%%`)를 파싱해 렌더링해요.
- `%c`는 이어지는 CSS 문자열을 파싱해서 이후 텍스트 세그먼트에 인라인 스타일로 적용해요. 새 `%c`가 등장하면 스타일이 교체돼요(Chrome DevTools 동작과 동일).
- 로그 캡처 로직(`setupLogMonitor`)과 `LogEntry` 타입은 건드리지 않고, **렌더링 시점**(`LogPanel`)에서만 파싱해요. 원본 `args`를 그대로 보존해 호환성을 유지해요.
- example 앱에 "Test CSS Console Log" 버튼을 추가해 수동 검증할 수 있어요.

### 구현

- `package/src/utils/parseFormat.ts` — `parseConsoleArgs(args)` → `{ segments, rest }`. 정규식 기반 스캔으로 포맷 지정자별 분기 처리.
- `package/src/utils/parseCssStyle.ts` — CSS 문자열 → `Record<string, string>` 변환. `url()`/`expression()`/`@import` 같은 위험 패턴은 drop.
- `package/src/components/LogPanel.tsx` — `log.args.map` 부분을 `segments` + `rest` 렌더링으로 교체. Lynx가 지원 안 하는 CSS 속성은 런타임에서 무시되도록 둬요.

## Test plan

- [x] `yarn dev:example`로 example 앱 실행 후 "Test CSS Console Log" 버튼 탭
- [x] `[Css Test]` 배지가 어두운 배경 + 핑크 텍스트로 렌더되는지 확인
- [x] 뒤의 `screen:home/tab:feed`는 주황 볼드로 렌더되는지 확인
- [x] `mixed format: alice got 42 points (59.95fps)` 텍스트로 치환되는지 확인
- [x] `%o` 예제에서 객체가 기존 토글 UI로 렌더되고 뒤의 `'end'`도 함께 표시되는지 확인
- [x] `escaped % percent`로 `%%`가 리터럴 `%`로 표시되는지 확인
- [x] 포맷 문자열이 없는 기존 로그가 regression 없이 동작하는지 확인

![Screenshot_20260421_154407_LynxExplorer.jpg](https://github.com/user-attachments/assets/c6a7e020-6398-4d38-9001-71054273f694)

