### PR TITLE
feat: BottomSheet에 키보드 회피 기능 추가

### DIFF
--- a/.changeset/ios-keyboard-avoidance.md
+++ b/.changeset/ios-keyboard-avoidance.md
@@ -1,0 +1,5 @@
+---
+"lynx-console": minor
+---
+
+Add keyboard avoidance for inputs inside `BottomSheet`. When the on-screen keyboard appears, the sheet expands by the keyboard height (capped at the max) and adds matching bottom padding so `<input>` elements (e.g. search, REPL) stay visible above the keyboard on iOS and Android.

--- a/package/src/components/BottomSheet.tsx
+++ b/package/src/components/BottomSheet.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useEffect, useState } from "@lynx-js/react";
 import type { BaseTouchEvent, Target } from "@lynx-js/types";
+import { useKeyboardHeight } from "../hooks/useKeyboardHeight";
 import { useThemeColors } from "../styles/ThemeContext";
 import { duration, fontWeight } from "../styles/theme";
 import "./BottomSheet.css";
@@ -41,6 +42,7 @@ export default function BottomSheet({
   );
   const [isOpening, setIsOpening] = useState(true);
   const [isClosing, setIsClosing] = useState(false);
+  const keyboardHeight = useKeyboardHeight();
 
   // 닫기 애니메이션 처리
   const handleClose = () => {
@@ -114,12 +116,21 @@ export default function BottomSheet({
           catchtap={() => {}}
           style={{
             background: colors.bg.layerFloating,
-            height: `${isDragging ? tempHeight : sheetHeight}px`,
+            height: `${
+              keyboardHeight > 0
+                ? Math.min(
+                    MAX_HEIGHT,
+                    (isDragging ? tempHeight : sheetHeight) + keyboardHeight,
+                  )
+                : isDragging
+                  ? tempHeight
+                  : sheetHeight
+            }px`,
             transform:
               isOpening || isClosing ? "translateY(100%)" : "translateY(0)",
             transition: isDragging
               ? "none"
-              : `transform ${duration.d6} cubic-bezier(0.4, 0, 0.2, 1)`,
+              : `transform ${duration.d6} cubic-bezier(0.4, 0, 0.2, 1), height ${duration.d6} cubic-bezier(0.4, 0, 0.2, 1)`,
           }}
         >
           {/* catchtap: 이벤트 버블링 차단 */}
@@ -150,7 +161,10 @@ export default function BottomSheet({
           <view
             className="bs-body"
             style={{
-              paddingBottom: safeAreaInsetBottom,
+              paddingBottom:
+                keyboardHeight > 0
+                  ? `${keyboardHeight}px`
+                  : safeAreaInsetBottom,
             }}
           >
             {children}

--- a/package/src/hooks/useKeyboardHeight.ts
+++ b/package/src/hooks/useKeyboardHeight.ts
@@ -1,0 +1,14 @@
+import { useLynxGlobalEventListener, useState } from "@lynx-js/react";
+
+export function useKeyboardHeight() {
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+
+  useLynxGlobalEventListener(
+    "keyboardstatuschanged",
+    (status: "on" | "off", height: number) => {
+      setKeyboardHeight(status === "on" ? height : 0);
+    },
+  );
+
+  return keyboardHeight;
+}


### PR DESCRIPTION

## Summary

- 바텀시트 내부의 `<input>` 요소(검색창, REPL 등)가 키보드에 가려지지 않도록 키보드 높이만큼 시트를 확장하고 body에 동일한 `paddingBottom`을 적용
- `useLynxGlobalEventListener("keyboardstatuschanged", ...)` 기반 `useKeyboardHeight` 훅 추가
- 시트 높이 전환에 `height` 트랜지션 추가해 키보드 등장/사라짐 시 자연스럽게 애니메이션

## Test plan

- [ ] iOS에서 바텀시트 열고 검색 input 탭 → 시트가 키보드 위로 올라가며 input이 보임
- [ ] iOS에서 REPL input 탭 → 동일하게 동작
- [ ] Android에서 동일 시나리오 확인
- [ ] 키보드 열린 상태에서 backdrop 탭 → 닫기 애니메이션이 자연스럽게 동작
- [ ] 키보드 열린 상태에서 드래그 리사이즈 정상 동작 (MAX_HEIGHT로 capped)