### PR TITLE
chore: void rerender on pipeline events

### DIFF
--- a/.changeset/refactor-uselatestfcp.md
+++ b/.changeset/refactor-uselatestfcp.md
@@ -1,0 +1,9 @@
+---
+"lynx-console": patch
+---
+
+`LynxConsole`에서 `usePerformance`로 전체 `performances` 배열을 컴포넌트 상태에 복사해 들고 있던 패턴을, FCP만 구독하는 `useLatestFcp` 훅으로 분리.
+
+- 불필요한 컴포넌트 상태 제거 — `performances` 원본은 `__LYNX_CONSOLE__.state`에 그대로 있어 이중 보관할 필요가 없었음
+- 매 호출마다 새 배열이 들어와 사실상 무효였던 `useMemo` 제거
+- `useState` lazy initializer로 마운트 시점 FCP 값을 첫 렌더에 잡도록 변경 (기존엔 `useEffect` 후에야 채워짐)

--- a/package/src/hooks/index.ts
+++ b/package/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useConsole } from "./useConsole";
+export { useLatestFcp } from "./useLatestFcp";
 export { useNetwork } from "./useNetwork";
 export { usePerformance } from "./usePerformance";

--- a/package/src/hooks/useLatestFcp.ts
+++ b/package/src/hooks/useLatestFcp.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "@lynx-js/react";
+import type { PerformanceEntryData } from "../types";
+
+interface FcpMetric {
+  name: string;
+  duration: number;
+}
+
+interface MetricFcpRawEntry {
+  totalFcp?: FcpMetric;
+  lynxFcp?: FcpMetric;
+  fcp?: FcpMetric;
+}
+
+const pickFcp = (entry: PerformanceEntryData): FcpMetric | undefined => {
+  if (entry.entryType !== "metric" || entry.name !== "fcp") return undefined;
+  const raw = entry.rawEntry as MetricFcpRawEntry | undefined;
+  if (raw?.totalFcp?.duration !== undefined) return raw.totalFcp;
+  if (raw?.lynxFcp?.duration !== undefined) return raw.lynxFcp;
+  return undefined;
+};
+
+export const useLatestFcp = (): FcpMetric | undefined => {
+  const [fcp, setFcp] = useState<FcpMetric | undefined>(() => {
+    const performances =
+      globalThis.__LYNX_CONSOLE__?.state?.performances ?? [];
+    for (let i = performances.length - 1; i >= 0; i--) {
+      const entry = performances[i];
+      if (!entry) continue;
+      const found = pickFcp(entry);
+      if (found) return found;
+    }
+    return undefined;
+  });
+
+  useEffect(() => {
+    const state = globalThis.__LYNX_CONSOLE__?.state;
+    if (!state?.subscribePerformance) return;
+
+    const unsubscribe = state.subscribePerformance((entry) => {
+      const found = pickFcp(entry);
+      if (found) setFcp(found);
+    });
+
+    return unsubscribe;
+  }, []);
+
+  return fcp;
+};

--- a/package/src/hooks/useLatestFcp.ts
+++ b/package/src/hooks/useLatestFcp.ts
@@ -22,8 +22,7 @@ const pickFcp = (entry: PerformanceEntryData): FcpMetric | undefined => {
 
 export const useLatestFcp = (): FcpMetric | undefined => {
   const [fcp, setFcp] = useState<FcpMetric | undefined>(() => {
-    const performances =
-      globalThis.__LYNX_CONSOLE__?.state?.performances ?? [];
+    const performances = globalThis.__LYNX_CONSOLE__?.state?.performances ?? [];
     for (let i = performances.length - 1; i >= 0; i--) {
       const entry = performances[i];
       if (!entry) continue;

--- a/package/src/index.tsx
+++ b/package/src/index.tsx
@@ -10,7 +10,7 @@ import { ConsolePanel } from "./components/ConsolePanel.jsx";
 import "./components/FloatingButton.css";
 import "./styles/tokens.css";
 import { FloatingButton } from "./components/FloatingButton.jsx";
-import { usePerformance } from "./hooks/usePerformance";
+import { useLatestFcp } from "./hooks/useLatestFcp";
 import { ThemeProvider } from "./styles/ThemeContext";
 import { getColors } from "./styles/theme";
 import type { CustomTab } from "./types";
@@ -33,17 +33,6 @@ export interface LynxConsoleProps {
   };
 }
 
-interface FcpMetric {
-  name: string;
-  duration: number;
-}
-
-interface MetricFcpEntry {
-  totalFcp?: FcpMetric;
-  lynxFcp?: FcpMetric;
-  fcp?: FcpMetric;
-}
-
 const LynxConsole = forwardRef<LynxConsoleHandle, LynxConsoleProps>(
   (
     {
@@ -56,25 +45,8 @@ const LynxConsole = forwardRef<LynxConsoleHandle, LynxConsoleProps>(
   ) => {
     const [isOpen, setIsOpen] = useState(false);
     const [shouldClose, setShouldClose] = useState(false);
-    const { performances } = usePerformance();
+    const latestFcp = useLatestFcp();
     const colors = useMemo(() => getColors(theme), [theme]);
-
-    const latestFcp = useMemo(() => {
-      for (let i = performances.length - 1; i >= 0; i--) {
-        const perf = performances[i];
-        if (perf && perf.entryType === "metric" && perf.name === "fcp") {
-          const metricEntry = perf.rawEntry as MetricFcpEntry | undefined;
-          // totalFcp를 먼저 시도하고, 없으면 lynxFcp 반환
-          if (metricEntry?.totalFcp?.duration !== undefined) {
-            return metricEntry.totalFcp;
-          }
-          if (metricEntry?.lynxFcp?.duration !== undefined) {
-            return metricEntry.lynxFcp;
-          }
-        }
-      }
-      return undefined;
-    }, [performances]);
 
     useImperativeHandle(ref, () => ({
       open: () => {


### PR DESCRIPTION
## Summary

  `LynxConsole`이 `usePerformance`로 전체 `performances` 배열을 컴포넌트 상태에 복사해 들고 있었는데, 실제로 컴포넌트가 쓰는 건
  거기서 derive한 `latestFcp` 값 하나뿐이었어요. FCP만 구독하는 `useLatestFcp` 훅으로 분리했어요.