### PR TITLE
fix: FloatingButton에서 consume-slide-event 제거하여 iOS list 스크롤 jank 해소

### DIFF
--- a/.changeset/remove-consume-slide-event.md
+++ b/.changeset/remove-consume-slide-event.md
@@ -1,0 +1,9 @@
+---
+"lynx-console": patch
+---
+
+`FloatingButton`에서 `consume-slide-event={[[-180, 180]]}` 속성 제거.
+
+이 속성이 한 군데라도 set되면 iOS는 `UIPanGestureRecognizer`를 LynxView의 root view에 attach해요. 이 root-level recognizer가 UIKit gesture arena에서 list의 `UIScrollView` scroll recognizer와 협상하면서 `shouldBeRequiredToFailByGestureRecognizer: YES` 때문에 list scroll이 매 gesture 시작마다 Lynx pan recognizer의 fail을 기다리게 돼요. 결과적으로 `<list>` 페이지에서 스크롤 시작이 끈적한 느낌을 줘요. (Android는 MotionEvent 인터셉트 방식이라 동일 문제 없음.)
+
+FloatingButton의 드래그는 `useLongPressDrag`의 long-press 임계로 list scroll과 자연스럽게 구분되므로 이 속성 없이도 동작에 큰 영향 없을 것으로 예상.

--- a/package/src/components/FloatingButton.tsx
+++ b/package/src/components/FloatingButton.tsx
@@ -56,7 +56,6 @@ export const FloatingButton = ({
   return (
     <view
       className={"fb-wrapper"}
-      consume-slide-event={[[-180, 180]]}
       style={{
         ...positionStyle,
         transform: isDragging ? "scale(1.05)" : "scale(1)",


### PR DESCRIPTION
## Summary

`FloatingButton`에서 `consume-slide-event={[[-180, 180]]}` 속성을 제거해요. iOS에서 `<list>` 페이지에 lynx-console이 떠 있을 때          발생하는 스크롤 시작 끈적함(jank)을 해소하기 위한 변경이에요.

## 근본 원인 (iOS)
`consume-slide-event` 속성이 LynxView 안에서 한 군데라도 set되면, iOS는 root view에 `UIPanGestureRecognizer`를 attach해요.(`LynxEventHandler.m:629`). 이 root-level recognizer가 UIKit gesture arena에서 list의 `UIScrollView` scroll recognizer와 순서를 겨루는데, delegate 메소드가`shouldBeRequiredToFailByGestureRecognizer: YES`를 반환해서 list scroll이 매 gesture 시작마다 Lynx pan recognizer의 fail을 기다리게 돼요. 결과적으로 `<list>` 본문 어디서든 스크롤 시작 시 latency가 생겨요. (FloatingButton 위가 아니라 list 한복판에서 스크롤해도 발생)

## Android와의 차이
Android는 `MotionEvent` 인터셉트 방식(`TouchEventDispatcher.java:242-317`)으로 구현돼 있어 동일 문제가   없어요. DOWN 시점에 부모 체인을 한 번 walk해서 flag를 set하고, MOVE에서 flag가 없으면 즉시 return해서 추가 비용 0이에요.