### PR TITLE
fix: scrollToPosition invoke에 fail 핸들러 추가

### DIFF
--- a/.changeset/scroll-to-position-fail-handler.md
+++ b/.changeset/scroll-to-position-fail-handler.md
@@ -1,0 +1,5 @@
+---
+"lynx-console": patch
+---
+
+Add a `fail` handler to the `scrollToPosition` invoke in `LogPanel` to suppress the harmless warning that occurs when an in-progress smooth scroll is interrupted by consecutive logs.

--- a/package/src/components/LogPanel.tsx
+++ b/package/src/components/LogPanel.tsx
@@ -154,6 +154,8 @@ export const LogPanel = ({ logs, clearLogs }: LogPanelProps) => {
       ?.invoke({
         method: "scrollToPosition",
         params: { position: logsRef.current.length - 1, smooth },
+        // 연속 로그로 진행 중이던 smooth 스크롤이 중단될 때 나는 무해한 경고를 무시
+        fail: () => {},
       })
       .exec();
   };


### PR DESCRIPTION
## 요약

  연속 로그로 진행 중이던 smooth 스크롤이 중단될 때 나는 경고를 무시하도록
  `LogPanel`의 `scrollToPosition` invoke에 `fail` 핸들러를 추가했어요.

  ## 변경 사항

  - `package/src/components/LogPanel.tsx`: `scrollToPosition` invoke에 `fail: () => {}`
  추가
  - changeset (`patch`) 추가