### PR TITLE
add network search

### DIFF
--- a/.changeset/network-search.md
+++ b/.changeset/network-search.md
@@ -1,0 +1,5 @@
+---
+"lynx-console": minor
+---
+
+Add search to the Network panel. The search box matches against the request URL, request body, and response body. Matching requests auto-expand to the tab that contains the hit (response is preferred), the matched text is highlighted, and the list scrolls to the first match.

--- a/.changeset/network-search.md
+++ b/.changeset/network-search.md
@@ -2,4 +2,4 @@
 "lynx-console": minor
 ---
 
-Add search to the Network panel. The search box matches against the request URL, request body, and response body. Matching requests auto-expand to the tab that contains the hit (response is preferred), the matched text is highlighted, and the list scrolls to the first match.
+Add search to the Network panel. The search box matches against the request URL, request/response headers, and request/response bodies. Matching requests auto-expand to the tab that contains the hit, the matched text is highlighted, and the list scrolls to the match. Use the ▲/▼ buttons (or Enter) to jump between matches. Request/response headers are collapsed by default and expand on tap or when a match is inside them.

--- a/package/src/components/HighlightText.tsx
+++ b/package/src/components/HighlightText.tsx
@@ -4,6 +4,8 @@ import { fontWeight } from "../styles/theme";
 interface HighlightSegment {
   text: string;
   match: boolean;
+  // 일치 세그먼트일 때 해당 텍스트 안에서의 0-based 등장 순번
+  occurrence?: number;
 }
 
 // query에 일치하는 부분을 대소문자 구분 없이 잘라 세그먼트로 반환
@@ -17,6 +19,7 @@ export function splitHighlight(
   const lower = text.toLowerCase();
   const segments: HighlightSegment[] = [];
   let cursor = 0;
+  let occurrence = 0;
 
   while (cursor < text.length) {
     const idx = lower.indexOf(q, cursor);
@@ -27,7 +30,12 @@ export function splitHighlight(
     if (idx > cursor) {
       segments.push({ text: text.slice(cursor, idx), match: false });
     }
-    segments.push({ text: text.slice(idx, idx + q.length), match: true });
+    segments.push({
+      text: text.slice(idx, idx + q.length),
+      match: true,
+      occurrence,
+    });
+    occurrence += 1;
     cursor = idx + q.length;
   }
 
@@ -41,9 +49,31 @@ export function textIncludes(text: string | undefined, query: string): boolean {
   return text.toLowerCase().includes(q);
 }
 
+// text 안에 query가 몇 번 등장하는지 센다(대소문자 무시)
+export function countOccurrences(
+  text: string | undefined,
+  query: string,
+): number {
+  if (!text) return 0;
+  const q = query.trim().toLowerCase();
+  if (!q) return 0;
+  const lower = text.toLowerCase();
+  let count = 0;
+  let from = 0;
+  while (true) {
+    const idx = lower.indexOf(q, from);
+    if (idx === -1) break;
+    count += 1;
+    from = idx + q.length;
+  }
+  return count;
+}
+
 interface HighlightTextProps {
   text: string;
   query: string;
+  // 이 텍스트 안에서 "현재 선택된" 매치의 등장 순번(없으면 -1)
+  activeOccurrence?: number | undefined;
   className?: string | undefined;
   style?: Record<string, unknown> | undefined;
 }
@@ -52,10 +82,12 @@ interface HighlightTextProps {
  * query에 일치하는 부분을 강조 표시하는 텍스트.
  * 일치하지 않는 부분은 부모 <text>의 스타일을 그대로 상속하고,
  * 일치하는 부분만 중첩 <text>로 감싸 하이라이트 배경을 입힌다.
+ * activeOccurrence와 순번이 같은 매치는 "현재 선택" 스타일로 강조한다.
  */
 export const HighlightText = ({
   text,
   query,
+  activeOccurrence = -1,
   className,
   style,
 }: HighlightTextProps) => {
@@ -72,23 +104,27 @@ export const HighlightText = ({
 
   return (
     <text className={className} style={style}>
-      {segments.map((segment, index) =>
-        segment.match ? (
+      {segments.map((segment, index) => {
+        if (!segment.match) return segment.text;
+        const isActive = segment.occurrence === activeOccurrence;
+        return (
           <text
             // biome-ignore lint: 세그먼트는 텍스트 순서로 안정적
             key={`hl-${index}`}
             style={{
-              backgroundColor: colors.palette.yellow600,
-              color: colors.palette.staticWhite,
+              backgroundColor: isActive
+                ? colors.palette.yellow600
+                : colors.palette.yellow100,
+              color: isActive
+                ? colors.palette.staticWhite
+                : colors.palette.yellow900,
               fontWeight: fontWeight.bold,
             }}
           >
             {segment.text}
           </text>
-        ) : (
-          segment.text
-        ),
-      )}
+        );
+      })}
     </text>
   );
 };

--- a/package/src/components/HighlightText.tsx
+++ b/package/src/components/HighlightText.tsx
@@ -1,0 +1,94 @@
+import { useThemeColors } from "../styles/ThemeContext";
+import { fontWeight } from "../styles/theme";
+
+interface HighlightSegment {
+  text: string;
+  match: boolean;
+}
+
+// query에 일치하는 부분을 대소문자 구분 없이 잘라 세그먼트로 반환
+export function splitHighlight(
+  text: string,
+  query: string,
+): HighlightSegment[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [{ text, match: false }];
+
+  const lower = text.toLowerCase();
+  const segments: HighlightSegment[] = [];
+  let cursor = 0;
+
+  while (cursor < text.length) {
+    const idx = lower.indexOf(q, cursor);
+    if (idx === -1) {
+      segments.push({ text: text.slice(cursor), match: false });
+      break;
+    }
+    if (idx > cursor) {
+      segments.push({ text: text.slice(cursor, idx), match: false });
+    }
+    segments.push({ text: text.slice(idx, idx + q.length), match: true });
+    cursor = idx + q.length;
+  }
+
+  return segments;
+}
+
+export function textIncludes(text: string | undefined, query: string): boolean {
+  if (!text) return false;
+  const q = query.trim().toLowerCase();
+  if (!q) return false;
+  return text.toLowerCase().includes(q);
+}
+
+interface HighlightTextProps {
+  text: string;
+  query: string;
+  className?: string | undefined;
+  style?: Record<string, unknown> | undefined;
+}
+
+/**
+ * query에 일치하는 부분을 강조 표시하는 텍스트.
+ * 일치하지 않는 부분은 부모 <text>의 스타일을 그대로 상속하고,
+ * 일치하는 부분만 중첩 <text>로 감싸 하이라이트 배경을 입힌다.
+ */
+export const HighlightText = ({
+  text,
+  query,
+  className,
+  style,
+}: HighlightTextProps) => {
+  const colors = useThemeColors();
+  const segments = splitHighlight(text, query);
+
+  if (segments.length === 1 && !segments[0]?.match) {
+    return (
+      <text className={className} style={style}>
+        {text}
+      </text>
+    );
+  }
+
+  return (
+    <text className={className} style={style}>
+      {segments.map((segment, index) =>
+        segment.match ? (
+          <text
+            // biome-ignore lint: 세그먼트는 텍스트 순서로 안정적
+            key={`hl-${index}`}
+            style={{
+              backgroundColor: colors.palette.yellow600,
+              color: colors.palette.staticWhite,
+              fontWeight: fontWeight.bold,
+            }}
+          >
+            {segment.text}
+          </text>
+        ) : (
+          segment.text
+        ),
+      )}
+    </text>
+  );
+};

--- a/package/src/components/HighlightText.tsx
+++ b/package/src/components/HighlightText.tsx
@@ -113,11 +113,11 @@ export const HighlightText = ({
             key={`hl-${index}`}
             style={{
               backgroundColor: isActive
-                ? colors.palette.yellow600
-                : colors.palette.yellow100,
+                ? colors.highlight.activeBg
+                : colors.highlight.matchBg,
               color: isActive
-                ? colors.palette.staticWhite
-                : colors.palette.yellow900,
+                ? colors.highlight.activeText
+                : colors.highlight.matchText,
               fontWeight: fontWeight.bold,
             }}
           >

--- a/package/src/components/HighlightText.tsx
+++ b/package/src/components/HighlightText.tsx
@@ -8,25 +8,36 @@ interface HighlightSegment {
   occurrence?: number;
 }
 
+// query가 등장하는 시작 인덱스들을 대소문자 구분 없이 반환한다.
+// 강조(splitHighlight)와 카운트(countOccurrences)가 같은 매치 정의를
+// 공유하도록 하는 단일 출처. 한쪽만 바뀌어 어긋나는 일을 막는다.
+function matchIndices(text: string, query: string): number[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [];
+  const lower = text.toLowerCase();
+  const indices: number[] = [];
+  let from = 0;
+  while (true) {
+    const idx = lower.indexOf(q, from);
+    if (idx === -1) break;
+    indices.push(idx);
+    from = idx + q.length;
+  }
+  return indices;
+}
+
 // query에 일치하는 부분을 대소문자 구분 없이 잘라 세그먼트로 반환
 export function splitHighlight(
   text: string,
   query: string,
 ): HighlightSegment[] {
   const q = query.trim().toLowerCase();
-  if (!q) return [{ text, match: false }];
+  const indices = matchIndices(text, query);
+  if (indices.length === 0) return [{ text, match: false }];
 
-  const lower = text.toLowerCase();
   const segments: HighlightSegment[] = [];
   let cursor = 0;
-  let occurrence = 0;
-
-  while (cursor < text.length) {
-    const idx = lower.indexOf(q, cursor);
-    if (idx === -1) {
-      segments.push({ text: text.slice(cursor), match: false });
-      break;
-    }
+  indices.forEach((idx, occurrence) => {
     if (idx > cursor) {
       segments.push({ text: text.slice(cursor, idx), match: false });
     }
@@ -35,8 +46,10 @@ export function splitHighlight(
       match: true,
       occurrence,
     });
-    occurrence += 1;
     cursor = idx + q.length;
+  });
+  if (cursor < text.length) {
+    segments.push({ text: text.slice(cursor), match: false });
   }
 
   return segments;
@@ -55,18 +68,7 @@ export function countOccurrences(
   query: string,
 ): number {
   if (!text) return 0;
-  const q = query.trim().toLowerCase();
-  if (!q) return 0;
-  const lower = text.toLowerCase();
-  let count = 0;
-  let from = 0;
-  while (true) {
-    const idx = lower.indexOf(q, from);
-    if (idx === -1) break;
-    count += 1;
-    from = idx + q.length;
-  }
-  return count;
+  return matchIndices(text, query).length;
 }
 
 interface HighlightTextProps {

--- a/package/src/components/NetworkDetailSection.tsx
+++ b/package/src/components/NetworkDetailSection.tsx
@@ -1,17 +1,20 @@
 import { useThemeColors } from "../styles/ThemeContext";
 import { fontWeight } from "../styles/theme";
+import { HighlightText } from "./HighlightText";
 import "./NetworkPanel.css";
 
 interface NetworkDetailSectionProps {
   headers?: Record<string, string> | undefined;
   body?: string | undefined;
   error?: string | undefined;
+  highlightQuery?: string | undefined;
 }
 
 export const NetworkDetailSection = ({
   headers = {},
   body = "",
   error = "",
+  highlightQuery = "",
 }: NetworkDetailSectionProps) => {
   const colors = useThemeColors();
 
@@ -88,16 +91,16 @@ export const NetworkDetailSection = ({
           </text>
         )}
         {body && (
-          <text
+          <HighlightText
+            text={body}
+            query={highlightQuery}
             className={"np-bodyText t3"}
             style={{
               fontWeight: fontWeight.regular,
               color: colors.fg.neutral,
               backgroundColor: colors.bg.neutralWeak,
             }}
-          >
-            {body}
-          </text>
+          />
         )}
         {!error && !body && (
           <text

--- a/package/src/components/NetworkDetailSection.tsx
+++ b/package/src/components/NetworkDetailSection.tsx
@@ -8,6 +8,7 @@ interface NetworkDetailSectionProps {
   body?: string | undefined;
   error?: string | undefined;
   highlightQuery?: string | undefined;
+  activeOccurrence?: number | undefined;
 }
 
 export const NetworkDetailSection = ({
@@ -15,6 +16,7 @@ export const NetworkDetailSection = ({
   body = "",
   error = "",
   highlightQuery = "",
+  activeOccurrence = -1,
 }: NetworkDetailSectionProps) => {
   const colors = useThemeColors();
 
@@ -94,6 +96,7 @@ export const NetworkDetailSection = ({
           <HighlightText
             text={body}
             query={highlightQuery}
+            activeOccurrence={activeOccurrence}
             className={"np-bodyText t3"}
             style={{
               fontWeight: fontWeight.regular,

--- a/package/src/components/NetworkDetailSection.tsx
+++ b/package/src/components/NetworkDetailSection.tsx
@@ -1,4 +1,4 @@
-import { type RefObject, useState } from "@lynx-js/react";
+import { type RefObject, useEffect, useState } from "@lynx-js/react";
 import type { NodesRef } from "@lynx-js/types";
 import { matchNode } from "../hooks/useNetworkSearch";
 import { useThemeColors } from "../styles/ThemeContext";
@@ -43,6 +43,10 @@ export const NetworkDetailSection = ({
   );
   // 헤더는 기본 접힘. 검색 결과가 헤더에 있으면 자동으로 펼치고, 탭하면 수동 토글
   const [manualOpen, setManualOpen] = useState<boolean | null>(null);
+  // 검색어가 바뀌면 수동 상태를 초기화해 새 매치 여부를 자동으로 반영한다
+  useEffect(() => {
+    setManualOpen(null);
+  }, [highlightQuery]);
   const headersOpen = manualOpen ?? headerHasMatch;
 
   return (

--- a/package/src/components/NetworkDetailSection.tsx
+++ b/package/src/components/NetworkDetailSection.tsx
@@ -1,4 +1,5 @@
-import { useState } from "@lynx-js/react";
+import { type RefObject, useState } from "@lynx-js/react";
+import type { NodesRef } from "@lynx-js/types";
 import { matchNode } from "../hooks/useNetworkSearch";
 import { useThemeColors } from "../styles/ThemeContext";
 import { fontWeight } from "../styles/theme";
@@ -13,6 +14,10 @@ interface NetworkDetailSectionProps {
   highlightQuery?: string | undefined;
   // 이 항목 안에서 nodeKey에 해당하는 노드의 활성 매치 등장 순번(없으면 -1)
   getActiveOccurrence?: ((nodeKey: string) => number) | undefined;
+  // 활성 매치 노드면 스크롤용 ref를 돌려준다(아니면 undefined)
+  getNodeRef?:
+    | ((nodeKey: string) => RefObject<NodesRef> | undefined)
+    | undefined;
 }
 
 export const NetworkDetailSection = ({
@@ -22,8 +27,14 @@ export const NetworkDetailSection = ({
   error = "",
   highlightQuery = "",
   getActiveOccurrence = () => -1,
+  getNodeRef = () => undefined,
 }: NetworkDetailSectionProps) => {
   const colors = useThemeColors();
+
+  // 헤더 행 안의 key 또는 value가 활성 매치면 그 행에 스크롤 ref를 단다
+  const rowRef = (name: string) =>
+    getNodeRef(matchNode.headerKey(section, name)) ??
+    getNodeRef(matchNode.headerValue(section, name));
 
   const headerEntries = Object.entries(headers);
   const headerHasMatch = headerEntries.some(
@@ -64,6 +75,7 @@ export const NetworkDetailSection = ({
               {headerEntries.map(([key, value]) => (
                 <view
                   key={key}
+                  ref={rowRef(key)}
                   className={"np-tableRow"}
                   style={{ backgroundColor: colors.bg.neutralWeak }}
                 >
@@ -108,7 +120,10 @@ export const NetworkDetailSection = ({
       </view>
 
       {/* Body */}
-      <view className={"np-detailSection"}>
+      <view
+        className={"np-detailSection"}
+        ref={getNodeRef(matchNode.body(section))}
+      >
         <text
           className={"np-detailSectionTitle t3"}
           style={{ fontWeight: fontWeight.bold, color: colors.fg.neutral }}

--- a/package/src/components/NetworkDetailSection.tsx
+++ b/package/src/components/NetworkDetailSection.tsx
@@ -1,6 +1,7 @@
+import { useState } from "@lynx-js/react";
 import { useThemeColors } from "../styles/ThemeContext";
 import { fontWeight } from "../styles/theme";
-import { HighlightText } from "./HighlightText";
+import { HighlightText, textIncludes } from "./HighlightText";
 import "./NetworkPanel.css";
 
 interface NetworkDetailSectionProps {
@@ -20,112 +21,127 @@ export const NetworkDetailSection = ({
 }: NetworkDetailSectionProps) => {
   const colors = useThemeColors();
 
-  // 이 body에 현재 활성 매치가 있으면 스크롤 포커스가 body로 잘 잡히도록
-  // Headers보다 위에 렌더한다(헤더가 길어도 body가 밀려나지 않음)
-  const bodyFirst = activeOccurrence >= 0;
-
-  const headerSection = (
-    <view className={"np-detailSection"}>
-      <text
-        className={"np-detailSectionTitle t3"}
-        style={{ fontWeight: fontWeight.bold, color: colors.fg.neutral }}
-      >
-        Headers
-      </text>
-      {headers && Object.keys(headers).length > 0 ? (
-        <view className={"np-table"}>
-          {Object.entries(headers).map(([key, value]) => (
-            <view
-              key={key}
-              className={"np-tableRow"}
-              style={{ backgroundColor: colors.bg.neutralWeak }}
-            >
-              <text
-                className={"np-tableKey t3"}
-                style={{
-                  fontWeight: fontWeight.bold,
-                  color: colors.fg.neutralSubtle,
-                }}
-              >
-                {key}
-              </text>
-              <text
-                className={"np-tableValue t3"}
-                style={{
-                  fontWeight: fontWeight.regular,
-                  color: colors.fg.neutral,
-                }}
-              >
-                {value}
-              </text>
-            </view>
-          ))}
-        </view>
-      ) : (
-        <text
-          className={"np-emptyText t3"}
-          style={{
-            fontWeight: fontWeight.regular,
-            color: colors.fg.disabled,
-          }}
-        >
-          No headers
-        </text>
-      )}
-    </view>
+  const headerEntries = Object.entries(headers);
+  const headerHasMatch = headerEntries.some(
+    ([key, value]) =>
+      textIncludes(key, highlightQuery) || textIncludes(value, highlightQuery),
   );
-
-  const bodySection = (
-    <view className={"np-detailSection"}>
-      <text
-        className={"np-detailSectionTitle t3"}
-        style={{ fontWeight: fontWeight.bold, color: colors.fg.neutral }}
-      >
-        Body
-      </text>
-      {error && (
-        <text
-          className={"np-errorText t3"}
-          style={{
-            fontWeight: fontWeight.regular,
-            color: colors.palette.red600,
-            backgroundColor: colors.palette.red100,
-          }}
-        >
-          {error}
-        </text>
-      )}
-      {body && (
-        <HighlightText
-          text={body}
-          query={highlightQuery}
-          activeOccurrence={activeOccurrence}
-          className={"np-bodyText t3"}
-          style={{
-            fontWeight: fontWeight.regular,
-            color: colors.fg.neutral,
-            backgroundColor: colors.bg.neutralWeak,
-          }}
-        />
-      )}
-      {!error && !body && (
-        <text
-          className={"np-emptyText t3"}
-          style={{
-            fontWeight: fontWeight.regular,
-            color: colors.fg.disabled,
-          }}
-        >
-          No body
-        </text>
-      )}
-    </view>
-  );
+  // 헤더는 기본 접힘. 검색 결과가 헤더에 있으면 자동으로 펼치고, 탭하면 수동 토글
+  const [manualOpen, setManualOpen] = useState<boolean | null>(null);
+  const headersOpen = manualOpen ?? headerHasMatch;
 
   return (
     <>
-      {bodyFirst ? bodySection : headerSection}
-      {bodyFirst ? headerSection : bodySection}
+      {/* Headers (토글) */}
+      <view className={"np-detailSection"}>
+        <view
+          className={"np-detailSectionHeader"}
+          bindtap={() => setManualOpen(!headersOpen)}
+        >
+          <text
+            className={"t2"}
+            style={{
+              fontWeight: fontWeight.regular,
+              color: colors.fg.neutralSubtle,
+            }}
+          >
+            {headersOpen ? "▼" : "▶"}
+          </text>
+          <text
+            className={"t3"}
+            style={{ fontWeight: fontWeight.bold, color: colors.fg.neutral }}
+          >
+            Headers
+          </text>
+        </view>
+        {headersOpen &&
+          (headerEntries.length > 0 ? (
+            <view className={"np-table"}>
+              {headerEntries.map(([key, value]) => (
+                <view
+                  key={key}
+                  className={"np-tableRow"}
+                  style={{ backgroundColor: colors.bg.neutralWeak }}
+                >
+                  <HighlightText
+                    text={key}
+                    query={highlightQuery}
+                    className={"np-tableKey t3"}
+                    style={{
+                      fontWeight: fontWeight.bold,
+                      color: colors.fg.neutralSubtle,
+                    }}
+                  />
+                  <HighlightText
+                    text={value}
+                    query={highlightQuery}
+                    className={"np-tableValue t3"}
+                    style={{
+                      fontWeight: fontWeight.regular,
+                      color: colors.fg.neutral,
+                    }}
+                  />
+                </view>
+              ))}
+            </view>
+          ) : (
+            <text
+              className={"np-emptyText t3"}
+              style={{
+                fontWeight: fontWeight.regular,
+                color: colors.fg.disabled,
+              }}
+            >
+              No headers
+            </text>
+          ))}
+      </view>
+
+      {/* Body */}
+      <view className={"np-detailSection"}>
+        <text
+          className={"np-detailSectionTitle t3"}
+          style={{ fontWeight: fontWeight.bold, color: colors.fg.neutral }}
+        >
+          Body
+        </text>
+        {error && (
+          <text
+            className={"np-errorText t3"}
+            style={{
+              fontWeight: fontWeight.regular,
+              color: colors.palette.red600,
+              backgroundColor: colors.palette.red100,
+            }}
+          >
+            {error}
+          </text>
+        )}
+        {body && (
+          <HighlightText
+            text={body}
+            query={highlightQuery}
+            activeOccurrence={activeOccurrence}
+            className={"np-bodyText t3"}
+            style={{
+              fontWeight: fontWeight.regular,
+              color: colors.fg.neutral,
+              backgroundColor: colors.bg.neutralWeak,
+            }}
+          />
+        )}
+        {!error && !body && (
+          <text
+            className={"np-emptyText t3"}
+            style={{
+              fontWeight: fontWeight.regular,
+              color: colors.fg.disabled,
+            }}
+          >
+            No body
+          </text>
+        )}
+      </view>
     </>
   );
 };

--- a/package/src/components/NetworkDetailSection.tsx
+++ b/package/src/components/NetworkDetailSection.tsx
@@ -1,23 +1,27 @@
 import { useState } from "@lynx-js/react";
+import { matchNode } from "../hooks/useNetworkSearch";
 import { useThemeColors } from "../styles/ThemeContext";
 import { fontWeight } from "../styles/theme";
 import { HighlightText, textIncludes } from "./HighlightText";
 import "./NetworkPanel.css";
 
 interface NetworkDetailSectionProps {
+  section: "request" | "response";
   headers?: Record<string, string> | undefined;
   body?: string | undefined;
   error?: string | undefined;
   highlightQuery?: string | undefined;
-  activeOccurrence?: number | undefined;
+  // 이 항목 안에서 nodeKey에 해당하는 노드의 활성 매치 등장 순번(없으면 -1)
+  getActiveOccurrence?: ((nodeKey: string) => number) | undefined;
 }
 
 export const NetworkDetailSection = ({
+  section,
   headers = {},
   body = "",
   error = "",
   highlightQuery = "",
-  activeOccurrence = -1,
+  getActiveOccurrence = () => -1,
 }: NetworkDetailSectionProps) => {
   const colors = useThemeColors();
 
@@ -66,6 +70,9 @@ export const NetworkDetailSection = ({
                   <HighlightText
                     text={key}
                     query={highlightQuery}
+                    activeOccurrence={getActiveOccurrence(
+                      matchNode.headerKey(section, key),
+                    )}
                     className={"np-tableKey t3"}
                     style={{
                       fontWeight: fontWeight.bold,
@@ -75,6 +82,9 @@ export const NetworkDetailSection = ({
                   <HighlightText
                     text={value}
                     query={highlightQuery}
+                    activeOccurrence={getActiveOccurrence(
+                      matchNode.headerValue(section, key),
+                    )}
                     className={"np-tableValue t3"}
                     style={{
                       fontWeight: fontWeight.regular,
@@ -121,7 +131,7 @@ export const NetworkDetailSection = ({
           <HighlightText
             text={body}
             query={highlightQuery}
-            activeOccurrence={activeOccurrence}
+            activeOccurrence={getActiveOccurrence(matchNode.body(section))}
             className={"np-bodyText t3"}
             style={{
               fontWeight: fontWeight.regular,

--- a/package/src/components/NetworkDetailSection.tsx
+++ b/package/src/components/NetworkDetailSection.tsx
@@ -1,4 +1,4 @@
-import { type RefObject, useEffect, useState } from "@lynx-js/react";
+import { type RefObject, useState } from "@lynx-js/react";
 import type { NodesRef } from "@lynx-js/types";
 import { matchNode } from "../hooks/useNetworkSearch";
 import { useThemeColors } from "../styles/ThemeContext";
@@ -43,10 +43,13 @@ export const NetworkDetailSection = ({
   );
   // 헤더는 기본 접힘. 검색 결과가 헤더에 있으면 자동으로 펼치고, 탭하면 수동 토글
   const [manualOpen, setManualOpen] = useState<boolean | null>(null);
-  // 검색어가 바뀌면 수동 상태를 초기화해 새 매치 여부를 자동으로 반영한다
-  useEffect(() => {
+  // 검색어가 바뀌면 수동 상태를 초기화해 새 매치 여부를 자동으로 반영한다.
+  // effect 대신 렌더 단계에서 직접 리셋(추가 페인트·깜빡임 없음 — React 권장 패턴)
+  const [prevQuery, setPrevQuery] = useState(highlightQuery);
+  if (prevQuery !== highlightQuery) {
+    setPrevQuery(highlightQuery);
     setManualOpen(null);
-  }, [highlightQuery]);
+  }
   const headersOpen = manualOpen ?? headerHasMatch;
 
   return (

--- a/package/src/components/NetworkDetailSection.tsx
+++ b/package/src/components/NetworkDetailSection.tsx
@@ -20,103 +20,112 @@ export const NetworkDetailSection = ({
 }: NetworkDetailSectionProps) => {
   const colors = useThemeColors();
 
+  // 이 body에 현재 활성 매치가 있으면 스크롤 포커스가 body로 잘 잡히도록
+  // Headers보다 위에 렌더한다(헤더가 길어도 body가 밀려나지 않음)
+  const bodyFirst = activeOccurrence >= 0;
+
+  const headerSection = (
+    <view className={"np-detailSection"}>
+      <text
+        className={"np-detailSectionTitle t3"}
+        style={{ fontWeight: fontWeight.bold, color: colors.fg.neutral }}
+      >
+        Headers
+      </text>
+      {headers && Object.keys(headers).length > 0 ? (
+        <view className={"np-table"}>
+          {Object.entries(headers).map(([key, value]) => (
+            <view
+              key={key}
+              className={"np-tableRow"}
+              style={{ backgroundColor: colors.bg.neutralWeak }}
+            >
+              <text
+                className={"np-tableKey t3"}
+                style={{
+                  fontWeight: fontWeight.bold,
+                  color: colors.fg.neutralSubtle,
+                }}
+              >
+                {key}
+              </text>
+              <text
+                className={"np-tableValue t3"}
+                style={{
+                  fontWeight: fontWeight.regular,
+                  color: colors.fg.neutral,
+                }}
+              >
+                {value}
+              </text>
+            </view>
+          ))}
+        </view>
+      ) : (
+        <text
+          className={"np-emptyText t3"}
+          style={{
+            fontWeight: fontWeight.regular,
+            color: colors.fg.disabled,
+          }}
+        >
+          No headers
+        </text>
+      )}
+    </view>
+  );
+
+  const bodySection = (
+    <view className={"np-detailSection"}>
+      <text
+        className={"np-detailSectionTitle t3"}
+        style={{ fontWeight: fontWeight.bold, color: colors.fg.neutral }}
+      >
+        Body
+      </text>
+      {error && (
+        <text
+          className={"np-errorText t3"}
+          style={{
+            fontWeight: fontWeight.regular,
+            color: colors.palette.red600,
+            backgroundColor: colors.palette.red100,
+          }}
+        >
+          {error}
+        </text>
+      )}
+      {body && (
+        <HighlightText
+          text={body}
+          query={highlightQuery}
+          activeOccurrence={activeOccurrence}
+          className={"np-bodyText t3"}
+          style={{
+            fontWeight: fontWeight.regular,
+            color: colors.fg.neutral,
+            backgroundColor: colors.bg.neutralWeak,
+          }}
+        />
+      )}
+      {!error && !body && (
+        <text
+          className={"np-emptyText t3"}
+          style={{
+            fontWeight: fontWeight.regular,
+            color: colors.fg.disabled,
+          }}
+        >
+          No body
+        </text>
+      )}
+    </view>
+  );
+
   return (
     <>
-      {/* Headers */}
-      <view className={"np-detailSection"}>
-        <text
-          className={"np-detailSectionTitle t3"}
-          style={{ fontWeight: fontWeight.bold, color: colors.fg.neutral }}
-        >
-          Headers
-        </text>
-        {headers && Object.keys(headers).length > 0 ? (
-          <view className={"np-table"}>
-            {Object.entries(headers).map(([key, value]) => (
-              <view
-                key={key}
-                className={"np-tableRow"}
-                style={{ backgroundColor: colors.bg.neutralWeak }}
-              >
-                <text
-                  className={"np-tableKey t3"}
-                  style={{
-                    fontWeight: fontWeight.bold,
-                    color: colors.fg.neutralSubtle,
-                  }}
-                >
-                  {key}
-                </text>
-                <text
-                  className={"np-tableValue t3"}
-                  style={{
-                    fontWeight: fontWeight.regular,
-                    color: colors.fg.neutral,
-                  }}
-                >
-                  {value}
-                </text>
-              </view>
-            ))}
-          </view>
-        ) : (
-          <text
-            className={"np-emptyText t3"}
-            style={{
-              fontWeight: fontWeight.regular,
-              color: colors.fg.disabled,
-            }}
-          >
-            No headers
-          </text>
-        )}
-      </view>
-
-      {/* Body */}
-      <view className={"np-detailSection"}>
-        <text
-          className={"np-detailSectionTitle t3"}
-          style={{ fontWeight: fontWeight.bold, color: colors.fg.neutral }}
-        >
-          Body
-        </text>
-        {error && (
-          <text
-            className={"np-errorText t3"}
-            style={{
-              fontWeight: fontWeight.regular,
-              color: colors.palette.red600,
-              backgroundColor: colors.palette.red100,
-            }}
-          >
-            {error}
-          </text>
-        )}
-        {body && (
-          <HighlightText
-            text={body}
-            query={highlightQuery}
-            activeOccurrence={activeOccurrence}
-            className={"np-bodyText t3"}
-            style={{
-              fontWeight: fontWeight.regular,
-              color: colors.fg.neutral,
-              backgroundColor: colors.bg.neutralWeak,
-            }}
-          />
-        )}
-        {!error && !body && (
-          <text
-            className={"np-emptyText t3"}
-            style={{
-              fontWeight: fontWeight.regular,
-              color: colors.fg.disabled,
-            }}
-          >
-            No body
-          </text>
-        )}
-      </view>
+      {bodyFirst ? bodySection : headerSection}
+      {bodyFirst ? headerSection : bodySection}
     </>
   );
 };

--- a/package/src/components/NetworkGeneralSection.tsx
+++ b/package/src/components/NetworkGeneralSection.tsx
@@ -1,0 +1,66 @@
+import type { RefObject } from "@lynx-js/react";
+import type { NodesRef } from "@lynx-js/types";
+import { matchNode } from "../hooks/useNetworkSearch";
+import { useThemeColors } from "../styles/ThemeContext";
+import { fontWeight } from "../styles/theme";
+import type { NetworkEntry } from "../types";
+import { getGeneralInfo } from "../utils/networkFormat";
+import { HighlightText } from "./HighlightText";
+import "./NetworkPanel.css";
+
+interface NetworkGeneralSectionProps {
+  network: NetworkEntry;
+  searchQuery?: string | undefined;
+  // 이 항목 안에서 nodeKey에 해당하는 노드의 활성 매치 등장 순번(없으면 -1)
+  getActiveOccurrence?: ((nodeKey: string) => number) | undefined;
+  // 활성 매치 노드면 스크롤용 ref를 돌려준다(아니면 undefined)
+  getNodeRef?:
+    | ((nodeKey: string) => RefObject<NodesRef> | undefined)
+    | undefined;
+}
+
+export const NetworkGeneralSection = ({
+  network,
+  searchQuery = "",
+  getActiveOccurrence = () => -1,
+  getNodeRef = () => undefined,
+}: NetworkGeneralSectionProps) => {
+  const colors = useThemeColors();
+
+  return (
+    <view className={"np-table"}>
+      {getGeneralInfo(network).map((item) => {
+        // URL 행만 검색 대상 — 매치 시 강조·스크롤 ref를 단다
+        const isUrl = item.key === "URL";
+        return (
+          <view
+            key={item.key}
+            ref={isUrl ? getNodeRef(matchNode.url) : undefined}
+            className={"np-tableRow"}
+            style={{ backgroundColor: colors.bg.neutralWeak }}
+          >
+            <text
+              className={"np-tableKey t3"}
+              style={{
+                fontWeight: fontWeight.bold,
+                color: colors.fg.neutralSubtle,
+              }}
+            >
+              {item.key}
+            </text>
+            <HighlightText
+              text={item.value}
+              query={isUrl ? searchQuery : ""}
+              activeOccurrence={isUrl ? getActiveOccurrence(matchNode.url) : -1}
+              className={"np-tableValue t3"}
+              style={{
+                fontWeight: fontWeight.regular,
+                color: colors.fg.neutral,
+              }}
+            />
+          </view>
+        );
+      })}
+    </view>
+  );
+};

--- a/package/src/components/NetworkListItem.tsx
+++ b/package/src/components/NetworkListItem.tsx
@@ -1,0 +1,194 @@
+import type { RefObject } from "@lynx-js/react";
+import type { NodesRef } from "@lynx-js/types";
+import type { NetworkTab } from "../hooks/useNetworkSearch";
+import { useThemeColors } from "../styles/ThemeContext";
+import { fontWeight } from "../styles/theme";
+import type { NetworkEntry } from "../types";
+import {
+  extractPath,
+  formatDuration,
+  getItemBg,
+  getMethodColors,
+  getStatusCodeColor,
+  getStatusCodeVariant,
+  TABS,
+} from "../utils/networkFormat";
+import { HighlightText } from "./HighlightText";
+import { NetworkDetailSection } from "./NetworkDetailSection";
+import { NetworkGeneralSection } from "./NetworkGeneralSection";
+import "./NetworkPanel.css";
+
+interface NetworkListItemProps {
+  network: NetworkEntry;
+  expanded: boolean;
+  onToggle: () => void;
+  activeTab: NetworkTab;
+  searchQuery: string;
+  onSelectTab: (tab: NetworkTab) => void;
+  // nodeKey 단위 접근자(항목 id는 부모에서 미리 바인딩됨)
+  getActiveOccurrence: (nodeKey: string) => number;
+  getNodeRef: (nodeKey: string) => RefObject<NodesRef> | undefined;
+}
+
+export const NetworkListItem = ({
+  network,
+  expanded,
+  onToggle,
+  activeTab,
+  searchQuery,
+  onSelectTab,
+  getActiveOccurrence,
+  getNodeRef,
+}: NetworkListItemProps) => {
+  const colors = useThemeColors();
+
+  return (
+    <view
+      className={"np-item"}
+      style={{
+        backgroundColor: getItemBg(colors, network.status),
+        borderBottomColor: colors.stroke.neutralWeak,
+      }}
+    >
+      <view className={"np-itemHeader"} bindtap={onToggle}>
+        <text
+          className={"np-method t2"}
+          style={{
+            fontWeight: fontWeight.bold,
+            ...getMethodColors(colors, network.method),
+          }}
+        >
+          {network.method}
+        </text>
+        {network.statusCode && (
+          <text
+            className={"np-statusCode t2"}
+            style={{
+              fontWeight: fontWeight.bold,
+              color: getStatusCodeColor(
+                colors,
+                getStatusCodeVariant(network.status, network.statusCode),
+              ),
+            }}
+          >
+            {network.statusCode}
+          </text>
+        )}
+        {network.status === "pending" && (
+          <text
+            className={"np-statusCode t2"}
+            style={{
+              fontWeight: fontWeight.bold,
+              color: colors.fg.neutralSubtle,
+            }}
+          >
+            Pending...
+          </text>
+        )}
+        <text
+          className={"np-time t2"}
+          style={{
+            fontWeight: fontWeight.regular,
+            color: colors.fg.neutralSubtle,
+          }}
+        >
+          {formatDuration(network.duration)}
+        </text>
+        <text
+          className={"np-time t2"}
+          style={{
+            fontWeight: fontWeight.regular,
+            color: colors.fg.neutralSubtle,
+          }}
+        >
+          {new Date(network.startTime).toISOString()}
+        </text>
+      </view>
+
+      <view bindtap={onToggle}>
+        <HighlightText
+          text={extractPath(network.url)}
+          query={searchQuery}
+          className={"np-path t3"}
+          style={{
+            fontWeight: fontWeight.regular,
+            color: colors.fg.neutral,
+          }}
+        />
+      </view>
+
+      {expanded && (
+        <view
+          className={"np-detailsContainer"}
+          style={{ borderTopColor: colors.stroke.neutralSubtle }}
+        >
+          {/* Tabs */}
+          <view className={"np-tabs"}>
+            {TABS.map(({ tab, label }) => {
+              const isActive = activeTab === tab;
+              return (
+                <view
+                  key={tab}
+                  className={"np-tab"}
+                  style={{
+                    backgroundColor: isActive
+                      ? colors.bg.neutralWeak
+                      : undefined,
+                  }}
+                  bindtap={() => onSelectTab(tab)}
+                >
+                  <text
+                    className={"np-tabText t4"}
+                    style={{
+                      fontWeight: fontWeight.medium,
+                      color: isActive
+                        ? colors.fg.neutral
+                        : colors.fg.neutralSubtle,
+                    }}
+                  >
+                    {label}
+                  </text>
+                </view>
+              );
+            })}
+          </view>
+
+          {/* Tab Content */}
+          <view className={"np-tabContent"}>
+            {activeTab === "general" && (
+              <NetworkGeneralSection
+                network={network}
+                searchQuery={searchQuery}
+                getActiveOccurrence={getActiveOccurrence}
+                getNodeRef={getNodeRef}
+              />
+            )}
+
+            {activeTab === "request" && (
+              <NetworkDetailSection
+                section="request"
+                headers={network.requestHeaders}
+                body={network.requestBody}
+                highlightQuery={searchQuery}
+                getActiveOccurrence={getActiveOccurrence}
+                getNodeRef={getNodeRef}
+              />
+            )}
+
+            {activeTab === "response" && (
+              <NetworkDetailSection
+                section="response"
+                headers={network.responseHeaders}
+                body={network.responseBody}
+                error={network.error}
+                highlightQuery={searchQuery}
+                getActiveOccurrence={getActiveOccurrence}
+                getNodeRef={getNodeRef}
+              />
+            )}
+          </view>
+        </view>
+      )}
+    </view>
+  );
+};

--- a/package/src/components/NetworkPanel.css
+++ b/package/src/components/NetworkPanel.css
@@ -10,8 +10,34 @@
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
+  padding-bottom: 3px;
+}
+
+.np-searchWrapper {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex: 1;
+  margin-right: 8px;
+  border-bottom-width: 1px;
+  border-bottom-style: solid;
+  gap: 8px;
+}
+
+.np-searchInput {
+  flex: 1;
+}
+
+.np-searchClear {
+  padding: 2px 4px;
+}
+
+.np-countRow {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
   margin-bottom: 8px;
-  padding-bottom: 4px;
+  padding-top: 4px;
 }
 
 .np-clearButton {

--- a/package/src/components/NetworkPanel.css
+++ b/package/src/components/NetworkPanel.css
@@ -32,6 +32,23 @@
   padding: 2px 4px;
 }
 
+.np-matchNav {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 4px;
+}
+
+.np-matchCount {
+  min-width: 28px;
+  text-align: right;
+}
+
+.np-matchNavButton {
+  padding: 1px 5px;
+  border-radius: 4px;
+}
+
 .np-countRow {
   display: flex;
   flex-direction: row;

--- a/package/src/components/NetworkPanel.css
+++ b/package/src/components/NetworkPanel.css
@@ -136,6 +136,14 @@
   margin-bottom: 8px;
 }
 
+.np-detailSectionHeader {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
 .np-table {
   display: flex;
   flex-direction: column;

--- a/package/src/components/NetworkPanel.tsx
+++ b/package/src/components/NetworkPanel.tsx
@@ -1,7 +1,9 @@
-import { useState } from "@lynx-js/react";
+import { useEffect, useMemo, useRef, useState } from "@lynx-js/react";
+import type { BaseEvent, InputInputEvent, NodesRef } from "@lynx-js/types";
 import { useThemeColors } from "../styles/ThemeContext";
 import { fontWeight, type ThemeColors } from "../styles/theme";
 import type { NetworkEntry } from "../types";
+import { HighlightText, textIncludes } from "./HighlightText";
 import { NetworkDetailSection } from "./NetworkDetailSection";
 import "./NetworkPanel.css";
 
@@ -11,6 +13,9 @@ interface NetworkPanelProps {
 }
 
 type TabType = "general" | "request" | "response";
+
+// 패널이 다시 마운트돼도 검색어를 유지
+let savedSearchQuery = "";
 
 function getMethodColors(colors: ThemeColors, method: string) {
   switch (method) {
@@ -78,7 +83,70 @@ export const NetworkPanel = ({
 }: NetworkPanelProps) => {
   const colors = useThemeColors();
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<TabType>("general");
+  // 항목별 탭 선택 상태(검색 일치 항목은 일치한 탭이 기본값)
+  const [tabOverrides, setTabOverrides] = useState<Record<string, TabType>>({});
+  const [searchQuery, setSearchQuery] = useState(savedSearchQuery);
+  const searchInputRef = useRef<NodesRef>(null);
+  const listRef = useRef<NodesRef>(null);
+
+  useEffect(() => {
+    savedSearchQuery = searchQuery;
+  }, [searchQuery]);
+
+  useEffect(() => {
+    if (savedSearchQuery) {
+      searchInputRef.current
+        ?.invoke({ method: "setValue", params: { value: savedSearchQuery } })
+        .exec();
+    }
+  }, []);
+
+  // 검색 일치 정보: 일치한 항목 id 집합과 항목별로 펼칠 탭
+  const matchInfo = useMemo(() => {
+    const ids = new Set<string>();
+    const matchedTab = new Map<string, TabType>();
+    if (!searchQuery.trim()) return { ids, matchedTab };
+
+    for (const network of networks) {
+      const inResponse = textIncludes(network.responseBody, searchQuery);
+      const inRequest = textIncludes(network.requestBody, searchQuery);
+      const inUrl = textIncludes(network.url, searchQuery);
+      if (inResponse || inRequest || inUrl) {
+        ids.add(network.id);
+        // response를 가장 우선해 자동으로 펼친다
+        matchedTab.set(
+          network.id,
+          inResponse ? "response" : inRequest ? "request" : "general",
+        );
+      }
+    }
+    return { ids, matchedTab };
+  }, [networks, searchQuery]);
+
+  const isExpanded = (id: string): boolean =>
+    selectedId === id || matchInfo.ids.has(id);
+
+  const getActiveTab = (id: string): TabType =>
+    tabOverrides[id] ?? matchInfo.matchedTab.get(id) ?? "general";
+
+  // 검색어가 바뀌면 첫 번째 일치 항목으로 스크롤 포커스
+  const firstMatchIndex = useMemo(() => {
+    if (!searchQuery.trim()) return -1;
+    return networks.findIndex((network) => matchInfo.ids.has(network.id));
+  }, [networks, matchInfo, searchQuery]);
+
+  useEffect(() => {
+    if (firstMatchIndex < 0) return;
+    listRef.current
+      ?.invoke({
+        method: "scrollToPosition",
+        params: { position: firstMatchIndex, smooth: true },
+        // 스크롤 도중 목록이 갱신되며 나는 무해한 경고를 무시
+        fail: () => {},
+      })
+      .exec();
+  }, [firstMatchIndex]);
+
   const formatDuration = (duration?: number): string => {
     if (!duration) return "-";
     if (duration < 1000) return `${duration}ms`;
@@ -131,15 +199,54 @@ export const NetworkPanel = ({
   return (
     <view className={"np-container"}>
       <view className={"np-header"}>
-        <text
-          className={"np-count t3"}
-          style={{
-            fontWeight: fontWeight.regular,
-            color: colors.fg.neutralSubtle,
-          }}
+        <view
+          className={"np-searchWrapper"}
+          style={{ borderBottomColor: colors.stroke.neutralSubtle }}
         >
-          Total: {networks.length} requests
-        </text>
+          <text
+            className={"np-searchPrompt t6"}
+            style={{
+              fontWeight: fontWeight.medium,
+              color: colors.fg.placeholder,
+            }}
+          >
+            {"›"}
+          </text>
+          <input
+            ref={searchInputRef}
+            className={"np-searchInput t3"}
+            style={{
+              fontWeight: fontWeight.regular,
+              color: colors.fg.neutral,
+              caretColor: colors.palette.green600,
+            }}
+            placeholder="Search url, request & response..."
+            bindinput={(e: BaseEvent<"bindinput", InputInputEvent>) =>
+              setSearchQuery(e.detail.value)
+            }
+          />
+          {searchQuery.length > 0 && (
+            <view
+              className={"np-searchClear"}
+              bindtap={() => {
+                setSearchQuery("");
+                searchInputRef.current
+                  ?.invoke({ method: "setValue", params: { value: "" } })
+                  .exec();
+              }}
+            >
+              <text
+                className={"np-searchClearText t3"}
+                style={{
+                  fontWeight: fontWeight.medium,
+                  color: colors.fg.placeholder,
+                }}
+              >
+                ✕
+              </text>
+            </view>
+          )}
+        </view>
         <view
           className={"np-clearButton"}
           style={{ backgroundColor: colors.bg.neutralWeak }}
@@ -157,6 +264,20 @@ export const NetworkPanel = ({
         </view>
       </view>
 
+      <view className={"np-countRow"}>
+        <text
+          className={"np-count t3"}
+          style={{
+            fontWeight: fontWeight.regular,
+            color: colors.fg.neutralSubtle,
+          }}
+        >
+          {searchQuery.trim()
+            ? `${matchInfo.ids.size} / ${networks.length} requests`
+            : `Total: ${networks.length} requests`}
+        </text>
+      </view>
+
       {networks.length === 0 ? (
         <view className={"np-placeholder"}>
           <text
@@ -170,7 +291,7 @@ export const NetworkPanel = ({
           </text>
         </view>
       ) : (
-        <list scroll-orientation="vertical" className={"np-list"}>
+        <list ref={listRef} scroll-orientation="vertical" className={"np-list"}>
           {networks.map((network) => (
             <list-item key={network.id} item-key={network.id}>
               <view
@@ -183,7 +304,7 @@ export const NetworkPanel = ({
                 <view
                   className={"np-itemHeader"}
                   bindtap={() =>
-                    setSelectedId(selectedId === network.id ? null : network.id)
+                    setSelectedId(isExpanded(network.id) ? null : network.id)
                   }
                 >
                   <text
@@ -243,100 +364,72 @@ export const NetworkPanel = ({
                   </text>
                 </view>
 
-                <text
-                  className={"np-path t3"}
-                  style={{
-                    fontWeight: fontWeight.regular,
-                    color: colors.fg.neutral,
-                  }}
+                <view
                   bindtap={() =>
-                    setSelectedId(selectedId === network.id ? null : network.id)
+                    setSelectedId(isExpanded(network.id) ? null : network.id)
                   }
                 >
-                  {extractPath(network.url)}
-                </text>
+                  <HighlightText
+                    text={extractPath(network.url)}
+                    query={searchQuery}
+                    className={"np-path t3"}
+                    style={{
+                      fontWeight: fontWeight.regular,
+                      color: colors.fg.neutral,
+                    }}
+                  />
+                </view>
 
-                {selectedId === network.id && (
+                {isExpanded(network.id) && (
                   <view
                     className={"np-detailsContainer"}
                     style={{ borderTopColor: colors.stroke.neutralSubtle }}
                   >
                     {/* Tabs */}
                     <view className={"np-tabs"}>
-                      <view
-                        className={"np-tab"}
-                        style={{
-                          backgroundColor:
-                            activeTab === "general"
-                              ? colors.bg.neutralWeak
-                              : undefined,
-                        }}
-                        bindtap={() => setActiveTab("general")}
-                      >
-                        <text
-                          className={"np-tabText t4"}
-                          style={{
-                            fontWeight: fontWeight.medium,
-                            color:
-                              activeTab === "general"
-                                ? colors.fg.neutral
-                                : colors.fg.neutralSubtle,
-                          }}
-                        >
-                          General
-                        </text>
-                      </view>
-                      <view
-                        className={"np-tab"}
-                        style={{
-                          backgroundColor:
-                            activeTab === "request"
-                              ? colors.bg.neutralWeak
-                              : undefined,
-                        }}
-                        bindtap={() => setActiveTab("request")}
-                      >
-                        <text
-                          className={"np-tabText t4"}
-                          style={{
-                            fontWeight: fontWeight.medium,
-                            color:
-                              activeTab === "request"
-                                ? colors.fg.neutral
-                                : colors.fg.neutralSubtle,
-                          }}
-                        >
-                          Request
-                        </text>
-                      </view>
-                      <view
-                        className={"np-tab"}
-                        style={{
-                          backgroundColor:
-                            activeTab === "response"
-                              ? colors.bg.neutralWeak
-                              : undefined,
-                        }}
-                        bindtap={() => setActiveTab("response")}
-                      >
-                        <text
-                          className={"np-tabText t4"}
-                          style={{
-                            fontWeight: fontWeight.medium,
-                            color:
-                              activeTab === "response"
-                                ? colors.fg.neutral
-                                : colors.fg.neutralSubtle,
-                          }}
-                        >
-                          Response
-                        </text>
-                      </view>
+                      {(["general", "request", "response"] as TabType[]).map(
+                        (tab) => {
+                          const isActive = getActiveTab(network.id) === tab;
+                          return (
+                            <view
+                              key={tab}
+                              className={"np-tab"}
+                              style={{
+                                backgroundColor: isActive
+                                  ? colors.bg.neutralWeak
+                                  : undefined,
+                              }}
+                              bindtap={() =>
+                                setTabOverrides((prev) => ({
+                                  ...prev,
+                                  [network.id]: tab,
+                                }))
+                              }
+                            >
+                              <text
+                                className={"np-tabText t4"}
+                                style={{
+                                  fontWeight: fontWeight.medium,
+                                  color: isActive
+                                    ? colors.fg.neutral
+                                    : colors.fg.neutralSubtle,
+                                }}
+                              >
+                                {tab === "general"
+                                  ? "General"
+                                  : tab === "request"
+                                    ? "Request"
+                                    : "Response"}
+                              </text>
+                            </view>
+                          );
+                        },
+                      )}
                     </view>
 
                     {/* Tab Content */}
                     <view className={"np-tabContent"}>
-                      {activeTab === "general" && (
+                      {getActiveTab(network.id) === "general" && (
                         <view className={"np-table"}>
                           {getGeneralInfo(network).map((item) => (
                             <view
@@ -353,32 +446,34 @@ export const NetworkPanel = ({
                               >
                                 {item.key}
                               </text>
-                              <text
+                              <HighlightText
+                                text={item.value}
+                                query={searchQuery}
                                 className={"np-tableValue t3"}
                                 style={{
                                   fontWeight: fontWeight.regular,
                                   color: colors.fg.neutral,
                                 }}
-                              >
-                                {item.value}
-                              </text>
+                              />
                             </view>
                           ))}
                         </view>
                       )}
 
-                      {activeTab === "request" && (
+                      {getActiveTab(network.id) === "request" && (
                         <NetworkDetailSection
                           headers={network.requestHeaders}
                           body={network.requestBody}
+                          highlightQuery={searchQuery}
                         />
                       )}
 
-                      {activeTab === "response" && (
+                      {getActiveTab(network.id) === "response" && (
                         <NetworkDetailSection
                           headers={network.responseHeaders}
                           body={network.responseBody}
                           error={network.error}
+                          highlightQuery={searchQuery}
                         />
                       )}
                     </view>

--- a/package/src/components/NetworkPanel.tsx
+++ b/package/src/components/NetworkPanel.tsx
@@ -3,7 +3,7 @@ import type { BaseEvent, InputInputEvent, NodesRef } from "@lynx-js/types";
 import { useThemeColors } from "../styles/ThemeContext";
 import { fontWeight, type ThemeColors } from "../styles/theme";
 import type { NetworkEntry } from "../types";
-import { HighlightText, textIncludes } from "./HighlightText";
+import { countOccurrences, HighlightText } from "./HighlightText";
 import { NetworkDetailSection } from "./NetworkDetailSection";
 import "./NetworkPanel.css";
 
@@ -13,6 +13,15 @@ interface NetworkPanelProps {
 }
 
 type TabType = "general" | "request" | "response";
+
+// 검색어의 개별 등장(매치) 하나를 가리킨다
+interface SearchMatch {
+  entryId: string;
+  entryIndex: number;
+  tab: TabType;
+  // 해당 필드 텍스트 안에서의 0-based 등장 순번
+  localIndex: number;
+}
 
 // 패널이 다시 마운트돼도 검색어를 유지
 let savedSearchQuery = "";
@@ -86,11 +95,15 @@ export const NetworkPanel = ({
   // 항목별 탭 선택 상태(검색 일치 항목은 일치한 탭이 기본값)
   const [tabOverrides, setTabOverrides] = useState<Record<string, TabType>>({});
   const [searchQuery, setSearchQuery] = useState(savedSearchQuery);
+  // 현재 선택된 매치 인덱스(전체 매치 배열 기준, 음수/초과는 wrap 처리)
+  const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
   const searchInputRef = useRef<NodesRef>(null);
   const listRef = useRef<NodesRef>(null);
 
   useEffect(() => {
     savedSearchQuery = searchQuery;
+    // 검색어가 바뀌면 첫 매치부터 다시 시작
+    setCurrentMatchIndex(0);
   }, [searchQuery]);
 
   useEffect(() => {
@@ -101,51 +114,84 @@ export const NetworkPanel = ({
     }
   }, []);
 
-  // 검색 일치 정보: 일치한 항목 id 집합과 항목별로 펼칠 탭
-  const matchInfo = useMemo(() => {
-    const ids = new Set<string>();
-    const matchedTab = new Map<string, TabType>();
-    if (!searchQuery.trim()) return { ids, matchedTab };
-
-    for (const network of networks) {
-      const inResponse = textIncludes(network.responseBody, searchQuery);
-      const inRequest = textIncludes(network.requestBody, searchQuery);
-      const inUrl = textIncludes(network.url, searchQuery);
-      if (inResponse || inRequest || inUrl) {
-        ids.add(network.id);
-        // response를 가장 우선해 자동으로 펼친다
-        matchedTab.set(
-          network.id,
-          inResponse ? "response" : inRequest ? "request" : "general",
-        );
+  // url / request body / response body 안의 모든 등장을 평탄한 매치 배열로 만든다
+  const matches = useMemo<SearchMatch[]>(() => {
+    if (!searchQuery.trim()) return [];
+    const result: SearchMatch[] = [];
+    networks.forEach((network, entryIndex) => {
+      const fields: { tab: TabType; text?: string }[] = [
+        { tab: "general", text: network.url },
+        { tab: "request", text: network.requestBody },
+        { tab: "response", text: network.responseBody },
+      ];
+      for (const { tab, text } of fields) {
+        const occurrences = countOccurrences(text, searchQuery);
+        for (let localIndex = 0; localIndex < occurrences; localIndex++) {
+          result.push({ entryId: network.id, entryIndex, tab, localIndex });
+        }
       }
-    }
-    return { ids, matchedTab };
+    });
+    return result;
   }, [networks, searchQuery]);
 
+  // wrap-around: 음수/초과 인덱스를 항상 유효 범위로 정규화
+  const activeIndex =
+    matches.length > 0
+      ? ((currentMatchIndex % matches.length) + matches.length) % matches.length
+      : 0;
+  const activeMatch = matches[activeIndex];
+
+  // 일치한 항목 id 집합과 항목별 기본 탭(첫 매치 기준)
+  const { matchedIds, defaultTabByEntry } = useMemo(() => {
+    const ids = new Set<string>();
+    const tabByEntry = new Map<string, TabType>();
+    for (const match of matches) {
+      ids.add(match.entryId);
+      if (!tabByEntry.has(match.entryId)) {
+        tabByEntry.set(match.entryId, match.tab);
+      }
+    }
+    return { matchedIds: ids, defaultTabByEntry: tabByEntry };
+  }, [matches]);
+
   const isExpanded = (id: string): boolean =>
-    selectedId === id || matchInfo.ids.has(id);
+    selectedId === id || matchedIds.has(id);
 
   const getActiveTab = (id: string): TabType =>
-    tabOverrides[id] ?? matchInfo.matchedTab.get(id) ?? "general";
+    tabOverrides[id] ?? defaultTabByEntry.get(id) ?? "general";
 
-  // 검색어가 바뀌면 첫 번째 일치 항목으로 스크롤 포커스
-  const firstMatchIndex = useMemo(() => {
-    if (!searchQuery.trim()) return -1;
-    return networks.findIndex((network) => matchInfo.ids.has(network.id));
-  }, [networks, matchInfo, searchQuery]);
+  // 이 항목/탭에서 현재 활성 매치의 등장 순번(아니면 -1)
+  const getActiveOccurrence = (id: string, tab: TabType): number =>
+    activeMatch && activeMatch.entryId === id && activeMatch.tab === tab
+      ? activeMatch.localIndex
+      : -1;
 
+  const goToMatch = (delta: number) => {
+    if (matches.length === 0) return;
+    setCurrentMatchIndex((prev) => prev + delta);
+  };
+
+  // 현재 매치가 바뀌면 해당 항목으로 스크롤하고 그 항목의 탭을 매치 위치로 전환
+  const activeEntryId = activeMatch?.entryId;
+  const activeEntryIndex = activeMatch?.entryIndex;
+  const activeTabForScroll = activeMatch?.tab;
   useEffect(() => {
-    if (firstMatchIndex < 0) return;
+    if (activeEntryId === undefined || activeEntryIndex === undefined) return;
     listRef.current
       ?.invoke({
         method: "scrollToPosition",
-        params: { position: firstMatchIndex, smooth: true },
+        params: { position: activeEntryIndex, smooth: true },
         // 스크롤 도중 목록이 갱신되며 나는 무해한 경고를 무시
         fail: () => {},
       })
       .exec();
-  }, [firstMatchIndex]);
+    if (activeTabForScroll) {
+      setTabOverrides((prev) => ({
+        ...prev,
+        [activeEntryId]: activeTabForScroll,
+      }));
+    }
+  }, [activeEntryId, activeEntryIndex, activeTabForScroll, activeIndex]);
 
   const formatDuration = (duration?: number): string => {
     if (!duration) return "-";
@@ -225,6 +271,57 @@ export const NetworkPanel = ({
               setSearchQuery(e.detail.value)
             }
           />
+          {searchQuery.trim().length > 0 && (
+            <view className={"np-matchNav"}>
+              <text
+                className={"np-matchCount t2"}
+                style={{
+                  fontWeight: fontWeight.medium,
+                  color: colors.fg.neutralSubtle,
+                }}
+              >
+                {matches.length > 0
+                  ? `${activeIndex + 1}/${matches.length}`
+                  : "0/0"}
+              </text>
+              <view
+                className={"np-matchNavButton"}
+                style={{ backgroundColor: colors.bg.neutralWeak }}
+                bindtap={() => goToMatch(-1)}
+              >
+                <text
+                  className={"np-matchNavText t3"}
+                  style={{
+                    fontWeight: fontWeight.bold,
+                    color:
+                      matches.length > 0
+                        ? colors.fg.neutralMuted
+                        : colors.fg.disabled,
+                  }}
+                >
+                  ▲
+                </text>
+              </view>
+              <view
+                className={"np-matchNavButton"}
+                style={{ backgroundColor: colors.bg.neutralWeak }}
+                bindtap={() => goToMatch(1)}
+              >
+                <text
+                  className={"np-matchNavText t3"}
+                  style={{
+                    fontWeight: fontWeight.bold,
+                    color:
+                      matches.length > 0
+                        ? colors.fg.neutralMuted
+                        : colors.fg.disabled,
+                  }}
+                >
+                  ▼
+                </text>
+              </view>
+            </view>
+          )}
           {searchQuery.length > 0 && (
             <view
               className={"np-searchClear"}
@@ -273,7 +370,7 @@ export const NetworkPanel = ({
           }}
         >
           {searchQuery.trim()
-            ? `${matchInfo.ids.size} / ${networks.length} requests`
+            ? `${matchedIds.size} / ${networks.length} requests`
             : `Total: ${networks.length} requests`}
         </text>
       </view>
@@ -446,15 +543,31 @@ export const NetworkPanel = ({
                               >
                                 {item.key}
                               </text>
-                              <HighlightText
-                                text={item.value}
-                                query={searchQuery}
-                                className={"np-tableValue t3"}
-                                style={{
-                                  fontWeight: fontWeight.regular,
-                                  color: colors.fg.neutral,
-                                }}
-                              />
+                              {item.key === "URL" ? (
+                                <HighlightText
+                                  text={item.value}
+                                  query={searchQuery}
+                                  activeOccurrence={getActiveOccurrence(
+                                    network.id,
+                                    "general",
+                                  )}
+                                  className={"np-tableValue t3"}
+                                  style={{
+                                    fontWeight: fontWeight.regular,
+                                    color: colors.fg.neutral,
+                                  }}
+                                />
+                              ) : (
+                                <text
+                                  className={"np-tableValue t3"}
+                                  style={{
+                                    fontWeight: fontWeight.regular,
+                                    color: colors.fg.neutral,
+                                  }}
+                                >
+                                  {item.value}
+                                </text>
+                              )}
                             </view>
                           ))}
                         </view>
@@ -465,6 +578,10 @@ export const NetworkPanel = ({
                           headers={network.requestHeaders}
                           body={network.requestBody}
                           highlightQuery={searchQuery}
+                          activeOccurrence={getActiveOccurrence(
+                            network.id,
+                            "request",
+                          )}
                         />
                       )}
 
@@ -474,6 +591,10 @@ export const NetworkPanel = ({
                           body={network.responseBody}
                           error={network.error}
                           highlightQuery={searchQuery}
+                          activeOccurrence={getActiveOccurrence(
+                            network.id,
+                            "response",
+                          )}
                         />
                       )}
                     </view>

--- a/package/src/components/NetworkPanel.tsx
+++ b/package/src/components/NetworkPanel.tsx
@@ -1,30 +1,23 @@
-import { useEffect, useMemo, useRef, useState } from "@lynx-js/react";
-import type { BaseEvent, InputInputEvent, NodesRef } from "@lynx-js/types";
+import { useState } from "@lynx-js/react";
+import { type NetworkTab, useNetworkSearch } from "../hooks/useNetworkSearch";
 import { useThemeColors } from "../styles/ThemeContext";
 import { fontWeight, type ThemeColors } from "../styles/theme";
 import type { NetworkEntry } from "../types";
-import { countOccurrences, HighlightText } from "./HighlightText";
+import { HighlightText } from "./HighlightText";
 import { NetworkDetailSection } from "./NetworkDetailSection";
 import "./NetworkPanel.css";
+import { NetworkSearchBar } from "./NetworkSearchBar";
 
 interface NetworkPanelProps {
   networks: NetworkEntry[];
   clearNetworks: () => void;
 }
 
-type TabType = "general" | "request" | "response";
-
-// 검색어의 개별 등장(매치) 하나를 가리킨다
-interface SearchMatch {
-  entryId: string;
-  entryIndex: number;
-  tab: TabType;
-  // 해당 필드 텍스트 안에서의 0-based 등장 순번
-  localIndex: number;
-}
-
-// 패널이 다시 마운트돼도 검색어를 유지
-let savedSearchQuery = "";
+const TABS: { tab: NetworkTab; label: string }[] = [
+  { tab: "general", label: "General" },
+  { tab: "request", label: "Request" },
+  { tab: "response", label: "Response" },
+];
 
 function getMethodColors(colors: ThemeColors, method: string) {
   switch (method) {
@@ -92,106 +85,13 @@ export const NetworkPanel = ({
 }: NetworkPanelProps) => {
   const colors = useThemeColors();
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  // 항목별 탭 선택 상태(검색 일치 항목은 일치한 탭이 기본값)
-  const [tabOverrides, setTabOverrides] = useState<Record<string, TabType>>({});
-  const [searchQuery, setSearchQuery] = useState(savedSearchQuery);
-  // 현재 선택된 매치 인덱스(전체 매치 배열 기준, 음수/초과는 wrap 처리)
-  const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
-  const searchInputRef = useRef<NodesRef>(null);
-  const listRef = useRef<NodesRef>(null);
-
-  useEffect(() => {
-    savedSearchQuery = searchQuery;
-    // 검색어가 바뀌면 첫 매치부터 다시 시작
-    setCurrentMatchIndex(0);
-  }, [searchQuery]);
-
-  useEffect(() => {
-    if (savedSearchQuery) {
-      searchInputRef.current
-        ?.invoke({ method: "setValue", params: { value: savedSearchQuery } })
-        .exec();
-    }
-  }, []);
-
-  // url / request body / response body 안의 모든 등장을 평탄한 매치 배열로 만든다
-  const matches = useMemo<SearchMatch[]>(() => {
-    if (!searchQuery.trim()) return [];
-    const result: SearchMatch[] = [];
-    networks.forEach((network, entryIndex) => {
-      const fields: { tab: TabType; text?: string }[] = [
-        { tab: "general", text: network.url },
-        { tab: "request", text: network.requestBody },
-        { tab: "response", text: network.responseBody },
-      ];
-      for (const { tab, text } of fields) {
-        const occurrences = countOccurrences(text, searchQuery);
-        for (let localIndex = 0; localIndex < occurrences; localIndex++) {
-          result.push({ entryId: network.id, entryIndex, tab, localIndex });
-        }
-      }
-    });
-    return result;
-  }, [networks, searchQuery]);
-
-  // wrap-around: 음수/초과 인덱스를 항상 유효 범위로 정규화
-  const activeIndex =
-    matches.length > 0
-      ? ((currentMatchIndex % matches.length) + matches.length) % matches.length
-      : 0;
-  const activeMatch = matches[activeIndex];
-
-  // 일치한 항목 id 집합과 항목별 기본 탭(첫 매치 기준)
-  const { matchedIds, defaultTabByEntry } = useMemo(() => {
-    const ids = new Set<string>();
-    const tabByEntry = new Map<string, TabType>();
-    for (const match of matches) {
-      ids.add(match.entryId);
-      if (!tabByEntry.has(match.entryId)) {
-        tabByEntry.set(match.entryId, match.tab);
-      }
-    }
-    return { matchedIds: ids, defaultTabByEntry: tabByEntry };
-  }, [matches]);
+  const search = useNetworkSearch(networks);
 
   const isExpanded = (id: string): boolean =>
-    selectedId === id || matchedIds.has(id);
+    selectedId === id || search.isMatched(id);
 
-  const getActiveTab = (id: string): TabType =>
-    tabOverrides[id] ?? defaultTabByEntry.get(id) ?? "general";
-
-  // 이 항목/탭에서 현재 활성 매치의 등장 순번(아니면 -1)
-  const getActiveOccurrence = (id: string, tab: TabType): number =>
-    activeMatch && activeMatch.entryId === id && activeMatch.tab === tab
-      ? activeMatch.localIndex
-      : -1;
-
-  const goToMatch = (delta: number) => {
-    if (matches.length === 0) return;
-    setCurrentMatchIndex((prev) => prev + delta);
-  };
-
-  // 현재 매치가 바뀌면 해당 항목으로 스크롤하고 그 항목의 탭을 매치 위치로 전환
-  const activeEntryId = activeMatch?.entryId;
-  const activeEntryIndex = activeMatch?.entryIndex;
-  const activeTabForScroll = activeMatch?.tab;
-  useEffect(() => {
-    if (activeEntryId === undefined || activeEntryIndex === undefined) return;
-    listRef.current
-      ?.invoke({
-        method: "scrollToPosition",
-        params: { position: activeEntryIndex, smooth: true },
-        // 스크롤 도중 목록이 갱신되며 나는 무해한 경고를 무시
-        fail: () => {},
-      })
-      .exec();
-    if (activeTabForScroll) {
-      setTabOverrides((prev) => ({
-        ...prev,
-        [activeEntryId]: activeTabForScroll,
-      }));
-    }
-  }, [activeEntryId, activeEntryIndex, activeTabForScroll, activeIndex]);
+  const toggleExpanded = (id: string) =>
+    setSelectedId(isExpanded(id) ? null : id);
 
   const formatDuration = (duration?: number): string => {
     if (!duration) return "-";
@@ -244,122 +144,15 @@ export const NetworkPanel = ({
 
   return (
     <view className={"np-container"}>
-      <view className={"np-header"}>
-        <view
-          className={"np-searchWrapper"}
-          style={{ borderBottomColor: colors.stroke.neutralSubtle }}
-        >
-          <text
-            className={"np-searchPrompt t6"}
-            style={{
-              fontWeight: fontWeight.medium,
-              color: colors.fg.placeholder,
-            }}
-          >
-            {"›"}
-          </text>
-          <input
-            ref={searchInputRef}
-            className={"np-searchInput t3"}
-            style={{
-              fontWeight: fontWeight.regular,
-              color: colors.fg.neutral,
-              caretColor: colors.palette.green600,
-            }}
-            placeholder="Search url, request & response..."
-            bindinput={(e: BaseEvent<"bindinput", InputInputEvent>) =>
-              setSearchQuery(e.detail.value)
-            }
-          />
-          {searchQuery.trim().length > 0 && (
-            <view className={"np-matchNav"}>
-              <text
-                className={"np-matchCount t2"}
-                style={{
-                  fontWeight: fontWeight.medium,
-                  color: colors.fg.neutralSubtle,
-                }}
-              >
-                {matches.length > 0
-                  ? `${activeIndex + 1}/${matches.length}`
-                  : "0/0"}
-              </text>
-              <view
-                className={"np-matchNavButton"}
-                style={{ backgroundColor: colors.bg.neutralWeak }}
-                bindtap={() => goToMatch(-1)}
-              >
-                <text
-                  className={"np-matchNavText t3"}
-                  style={{
-                    fontWeight: fontWeight.bold,
-                    color:
-                      matches.length > 0
-                        ? colors.fg.neutralMuted
-                        : colors.fg.disabled,
-                  }}
-                >
-                  ▲
-                </text>
-              </view>
-              <view
-                className={"np-matchNavButton"}
-                style={{ backgroundColor: colors.bg.neutralWeak }}
-                bindtap={() => goToMatch(1)}
-              >
-                <text
-                  className={"np-matchNavText t3"}
-                  style={{
-                    fontWeight: fontWeight.bold,
-                    color:
-                      matches.length > 0
-                        ? colors.fg.neutralMuted
-                        : colors.fg.disabled,
-                  }}
-                >
-                  ▼
-                </text>
-              </view>
-            </view>
-          )}
-          {searchQuery.length > 0 && (
-            <view
-              className={"np-searchClear"}
-              bindtap={() => {
-                setSearchQuery("");
-                searchInputRef.current
-                  ?.invoke({ method: "setValue", params: { value: "" } })
-                  .exec();
-              }}
-            >
-              <text
-                className={"np-searchClearText t3"}
-                style={{
-                  fontWeight: fontWeight.medium,
-                  color: colors.fg.placeholder,
-                }}
-              >
-                ✕
-              </text>
-            </view>
-          )}
-        </view>
-        <view
-          className={"np-clearButton"}
-          style={{ backgroundColor: colors.bg.neutralWeak }}
-          bindtap={clearNetworks}
-        >
-          <text
-            className={"np-clearButtonText t3"}
-            style={{
-              fontWeight: fontWeight.medium,
-              color: colors.fg.neutralMuted,
-            }}
-          >
-            🗑
-          </text>
-        </view>
-      </view>
+      <NetworkSearchBar
+        searchQuery={search.searchQuery}
+        setSearchQuery={search.setSearchQuery}
+        searchInputRef={search.searchInputRef}
+        totalMatches={search.totalMatches}
+        activeIndex={search.activeIndex}
+        goToMatch={search.goToMatch}
+        clearNetworks={clearNetworks}
+      />
 
       <view className={"np-countRow"}>
         <text
@@ -369,8 +162,8 @@ export const NetworkPanel = ({
             color: colors.fg.neutralSubtle,
           }}
         >
-          {searchQuery.trim()
-            ? `${matchedIds.size} / ${networks.length} requests`
+          {search.searchQuery.trim()
+            ? `${search.matchedCount} / ${networks.length} requests`
             : `Total: ${networks.length} requests`}
         </text>
       </view>
@@ -388,105 +181,104 @@ export const NetworkPanel = ({
           </text>
         </view>
       ) : (
-        <list ref={listRef} scroll-orientation="vertical" className={"np-list"}>
-          {networks.map((network) => (
-            <list-item key={network.id} item-key={network.id}>
-              <view
-                className={"np-item"}
-                style={{
-                  backgroundColor: getItemBg(colors, network.status),
-                  borderBottomColor: colors.stroke.neutralWeak,
-                }}
-              >
+        <list
+          ref={search.listRef}
+          scroll-orientation="vertical"
+          className={"np-list"}
+        >
+          {networks.map((network) => {
+            const activeTab = search.getActiveTab(network.id);
+            return (
+              <list-item key={network.id} item-key={network.id}>
                 <view
-                  className={"np-itemHeader"}
-                  bindtap={() =>
-                    setSelectedId(isExpanded(network.id) ? null : network.id)
-                  }
+                  className={"np-item"}
+                  style={{
+                    backgroundColor: getItemBg(colors, network.status),
+                    borderBottomColor: colors.stroke.neutralWeak,
+                  }}
                 >
-                  <text
-                    className={"np-method t2"}
-                    style={{
-                      fontWeight: fontWeight.bold,
-                      ...getMethodColors(colors, network.method),
-                    }}
+                  <view
+                    className={"np-itemHeader"}
+                    bindtap={() => toggleExpanded(network.id)}
                   >
-                    {network.method}
-                  </text>
-                  {network.statusCode && (
                     <text
-                      className={"np-statusCode t2"}
+                      className={"np-method t2"}
                       style={{
                         fontWeight: fontWeight.bold,
-                        color: getStatusCodeColor(
-                          colors,
-                          getStatusCodeVariant(
-                            network.status,
-                            network.statusCode,
-                          ),
-                        ),
+                        ...getMethodColors(colors, network.method),
                       }}
                     >
-                      {network.statusCode}
+                      {network.method}
                     </text>
-                  )}
-                  {network.status === "pending" && (
+                    {network.statusCode && (
+                      <text
+                        className={"np-statusCode t2"}
+                        style={{
+                          fontWeight: fontWeight.bold,
+                          color: getStatusCodeColor(
+                            colors,
+                            getStatusCodeVariant(
+                              network.status,
+                              network.statusCode,
+                            ),
+                          ),
+                        }}
+                      >
+                        {network.statusCode}
+                      </text>
+                    )}
+                    {network.status === "pending" && (
+                      <text
+                        className={"np-statusCode t2"}
+                        style={{
+                          fontWeight: fontWeight.bold,
+                          color: colors.fg.neutralSubtle,
+                        }}
+                      >
+                        Pending...
+                      </text>
+                    )}
                     <text
-                      className={"np-statusCode t2"}
+                      className={"np-time t2"}
                       style={{
-                        fontWeight: fontWeight.bold,
+                        fontWeight: fontWeight.regular,
                         color: colors.fg.neutralSubtle,
                       }}
                     >
-                      Pending...
+                      {formatDuration(network.duration)}
                     </text>
-                  )}
-                  <text
-                    className={"np-time t2"}
-                    style={{
-                      fontWeight: fontWeight.regular,
-                      color: colors.fg.neutralSubtle,
-                    }}
-                  >
-                    {formatDuration(network.duration)}
-                  </text>
-                  <text
-                    className={"np-time t2"}
-                    style={{
-                      fontWeight: fontWeight.regular,
-                      color: colors.fg.neutralSubtle,
-                    }}
-                  >
-                    {new Date(network.startTime).toISOString()}
-                  </text>
-                </view>
+                    <text
+                      className={"np-time t2"}
+                      style={{
+                        fontWeight: fontWeight.regular,
+                        color: colors.fg.neutralSubtle,
+                      }}
+                    >
+                      {new Date(network.startTime).toISOString()}
+                    </text>
+                  </view>
 
-                <view
-                  bindtap={() =>
-                    setSelectedId(isExpanded(network.id) ? null : network.id)
-                  }
-                >
-                  <HighlightText
-                    text={extractPath(network.url)}
-                    query={searchQuery}
-                    className={"np-path t3"}
-                    style={{
-                      fontWeight: fontWeight.regular,
-                      color: colors.fg.neutral,
-                    }}
-                  />
-                </view>
+                  <view bindtap={() => toggleExpanded(network.id)}>
+                    <HighlightText
+                      text={extractPath(network.url)}
+                      query={search.searchQuery}
+                      className={"np-path t3"}
+                      style={{
+                        fontWeight: fontWeight.regular,
+                        color: colors.fg.neutral,
+                      }}
+                    />
+                  </view>
 
-                {isExpanded(network.id) && (
-                  <view
-                    className={"np-detailsContainer"}
-                    style={{ borderTopColor: colors.stroke.neutralSubtle }}
-                  >
-                    {/* Tabs */}
-                    <view className={"np-tabs"}>
-                      {(["general", "request", "response"] as TabType[]).map(
-                        (tab) => {
-                          const isActive = getActiveTab(network.id) === tab;
+                  {isExpanded(network.id) && (
+                    <view
+                      className={"np-detailsContainer"}
+                      style={{ borderTopColor: colors.stroke.neutralSubtle }}
+                    >
+                      {/* Tabs */}
+                      <view className={"np-tabs"}>
+                        {TABS.map(({ tab, label }) => {
+                          const isActive = activeTab === tab;
                           return (
                             <view
                               key={tab}
@@ -496,12 +288,7 @@ export const NetworkPanel = ({
                                   ? colors.bg.neutralWeak
                                   : undefined,
                               }}
-                              bindtap={() =>
-                                setTabOverrides((prev) => ({
-                                  ...prev,
-                                  [network.id]: tab,
-                                }))
-                              }
+                              bindtap={() => search.selectTab(network.id, tab)}
                             >
                               <text
                                 className={"np-tabText t4"}
@@ -512,97 +299,89 @@ export const NetworkPanel = ({
                                     : colors.fg.neutralSubtle,
                                 }}
                               >
-                                {tab === "general"
-                                  ? "General"
-                                  : tab === "request"
-                                    ? "Request"
-                                    : "Response"}
+                                {label}
                               </text>
                             </view>
                           );
-                        },
-                      )}
-                    </view>
+                        })}
+                      </view>
 
-                    {/* Tab Content */}
-                    <view className={"np-tabContent"}>
-                      {getActiveTab(network.id) === "general" && (
-                        <view className={"np-table"}>
-                          {getGeneralInfo(network).map((item) => (
-                            <view
-                              key={item.key}
-                              className={"np-tableRow"}
-                              style={{ backgroundColor: colors.bg.neutralWeak }}
-                            >
-                              <text
-                                className={"np-tableKey t3"}
+                      {/* Tab Content */}
+                      <view className={"np-tabContent"}>
+                        {activeTab === "general" && (
+                          <view className={"np-table"}>
+                            {getGeneralInfo(network).map((item) => (
+                              <view
+                                key={item.key}
+                                className={"np-tableRow"}
                                 style={{
-                                  fontWeight: fontWeight.bold,
-                                  color: colors.fg.neutralSubtle,
+                                  backgroundColor: colors.bg.neutralWeak,
                                 }}
                               >
-                                {item.key}
-                              </text>
-                              {item.key === "URL" ? (
+                                <text
+                                  className={"np-tableKey t3"}
+                                  style={{
+                                    fontWeight: fontWeight.bold,
+                                    color: colors.fg.neutralSubtle,
+                                  }}
+                                >
+                                  {item.key}
+                                </text>
                                 <HighlightText
                                   text={item.value}
-                                  query={searchQuery}
-                                  activeOccurrence={getActiveOccurrence(
-                                    network.id,
-                                    "general",
-                                  )}
+                                  query={
+                                    item.key === "URL" ? search.searchQuery : ""
+                                  }
+                                  activeOccurrence={
+                                    item.key === "URL"
+                                      ? search.getActiveOccurrence(
+                                          network.id,
+                                          "general",
+                                        )
+                                      : -1
+                                  }
                                   className={"np-tableValue t3"}
                                   style={{
                                     fontWeight: fontWeight.regular,
                                     color: colors.fg.neutral,
                                   }}
                                 />
-                              ) : (
-                                <text
-                                  className={"np-tableValue t3"}
-                                  style={{
-                                    fontWeight: fontWeight.regular,
-                                    color: colors.fg.neutral,
-                                  }}
-                                >
-                                  {item.value}
-                                </text>
-                              )}
-                            </view>
-                          ))}
-                        </view>
-                      )}
+                              </view>
+                            ))}
+                          </view>
+                        )}
 
-                      {getActiveTab(network.id) === "request" && (
-                        <NetworkDetailSection
-                          headers={network.requestHeaders}
-                          body={network.requestBody}
-                          highlightQuery={searchQuery}
-                          activeOccurrence={getActiveOccurrence(
-                            network.id,
-                            "request",
-                          )}
-                        />
-                      )}
+                        {activeTab === "request" && (
+                          <NetworkDetailSection
+                            headers={network.requestHeaders}
+                            body={network.requestBody}
+                            highlightQuery={search.searchQuery}
+                            activeOccurrence={search.getActiveOccurrence(
+                              network.id,
+                              "request",
+                            )}
+                          />
+                        )}
 
-                      {getActiveTab(network.id) === "response" && (
-                        <NetworkDetailSection
-                          headers={network.responseHeaders}
-                          body={network.responseBody}
-                          error={network.error}
-                          highlightQuery={searchQuery}
-                          activeOccurrence={getActiveOccurrence(
-                            network.id,
-                            "response",
-                          )}
-                        />
-                      )}
+                        {activeTab === "response" && (
+                          <NetworkDetailSection
+                            headers={network.responseHeaders}
+                            body={network.responseBody}
+                            error={network.error}
+                            highlightQuery={search.searchQuery}
+                            activeOccurrence={search.getActiveOccurrence(
+                              network.id,
+                              "response",
+                            )}
+                          />
+                        )}
+                      </view>
                     </view>
-                  </view>
-                )}
-              </view>
-            </list-item>
-          ))}
+                  )}
+                </view>
+              </list-item>
+            );
+          })}
         </list>
       )}
     </view>

--- a/package/src/components/NetworkPanel.tsx
+++ b/package/src/components/NetworkPanel.tsx
@@ -1,14 +1,9 @@
 import { useState } from "@lynx-js/react";
-import {
-  matchNode,
-  type NetworkTab,
-  useNetworkSearch,
-} from "../hooks/useNetworkSearch";
+import { useNetworkSearch } from "../hooks/useNetworkSearch";
 import { useThemeColors } from "../styles/ThemeContext";
-import { fontWeight, type ThemeColors } from "../styles/theme";
+import { fontWeight } from "../styles/theme";
 import type { NetworkEntry } from "../types";
-import { HighlightText } from "./HighlightText";
-import { NetworkDetailSection } from "./NetworkDetailSection";
+import { NetworkListItem } from "./NetworkListItem";
 import "./NetworkPanel.css";
 import { NetworkSearchBar } from "./NetworkSearchBar";
 
@@ -17,133 +12,39 @@ interface NetworkPanelProps {
   clearNetworks: () => void;
 }
 
-const TABS: { tab: NetworkTab; label: string }[] = [
-  { tab: "general", label: "General" },
-  { tab: "request", label: "Request" },
-  { tab: "response", label: "Response" },
-];
-
-function getMethodColors(colors: ThemeColors, method: string) {
-  switch (method) {
-    case "GET":
-      return {
-        color: colors.palette.blue600,
-        backgroundColor: colors.palette.blue100,
-      };
-    case "POST":
-      return {
-        color: colors.palette.green600,
-        backgroundColor: colors.palette.green100,
-      };
-    case "PUT":
-      return {
-        color: colors.palette.yellow600,
-        backgroundColor: colors.palette.yellow100,
-      };
-    case "PATCH":
-      return {
-        color: colors.palette.purple600,
-        backgroundColor: colors.palette.purple100,
-      };
-    case "DELETE":
-      return {
-        color: colors.palette.red600,
-        backgroundColor: colors.palette.red100,
-      };
-    default:
-      return {
-        color: colors.fg.neutral,
-        backgroundColor: colors.bg.neutralWeak,
-      };
-  }
-}
-
-function getStatusCodeColor(
-  colors: ThemeColors,
-  variant: "success" | "error" | "pending",
-): string {
-  switch (variant) {
-    case "success":
-      return colors.palette.green600;
-    case "error":
-      return colors.palette.red600;
-    case "pending":
-      return colors.fg.neutralSubtle;
-  }
-}
-
-function getItemBg(colors: ThemeColors, status: string): string | undefined {
-  switch (status) {
-    case "pending":
-      return colors.palette.gray100;
-    case "error":
-      return colors.palette.red100;
-    default:
-      return undefined;
-  }
-}
-
 export const NetworkPanel = ({
   networks,
   clearNetworks,
 }: NetworkPanelProps) => {
   const colors = useThemeColors();
+  // 수동으로 펼친 단일 항목(아코디언). 검색 매치는 별도로 자동 펼침된다.
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  // 매치로 자동 펼쳐졌지만 사용자가 직접 접은 항목들(자동 펼침을 무시)
+  const [collapsedIds, setCollapsedIds] = useState<Set<string>>(new Set());
   const search = useNetworkSearch(networks);
 
-  const isExpanded = (id: string): boolean =>
-    selectedId === id || search.isMatched(id);
-
-  const toggleExpanded = (id: string) =>
-    setSelectedId(isExpanded(id) ? null : id);
-
-  const formatDuration = (duration?: number): string => {
-    if (!duration) return "-";
-    if (duration < 1000) return `${duration}ms`;
-    return `${(duration / 1000).toFixed(2)}s`;
+  const isExpanded = (id: string): boolean => {
+    if (collapsedIds.has(id)) return false;
+    return selectedId === id || search.isMatched(id);
   };
 
-  const extractPath = (url: string): string => {
-    const pathMatch = url.match(/^https?:\/\/[^/]+(.*)$/);
-    if (pathMatch?.[1]) {
-      return pathMatch[1].startsWith("/")
-        ? pathMatch[1].slice(1)
-        : pathMatch[1];
+  const toggleExpanded = (id: string): void => {
+    if (isExpanded(id)) {
+      // 접기: 아코디언 선택을 해제하고, 매치 항목이면 자동 펼침도 끈다
+      setSelectedId((cur) => (cur === id ? null : cur));
+      if (search.isMatched(id)) {
+        setCollapsedIds((prev) => new Set(prev).add(id));
+      }
+    } else {
+      // 펼치기: 아코디언 선택 + 접힘 표시 해제
+      setSelectedId(id);
+      setCollapsedIds((prev) => {
+        if (!prev.has(id)) return prev;
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
     }
-    return url;
-  };
-
-  const getGeneralInfo = (network: NetworkEntry) => {
-    return [
-      { key: "URL", value: network.url },
-      { key: "Method", value: network.method },
-      network.statusCode
-        ? { key: "Status", value: String(network.statusCode) }
-        : null,
-      {
-        key: "Request Time",
-        value: new Date(network.startTime).toISOString(),
-      },
-      network.endTime
-        ? {
-            key: "Response Time",
-            value: new Date(network.endTime).toISOString(),
-          }
-        : null,
-      network.duration
-        ? { key: "Duration", value: formatDuration(network.duration) }
-        : null,
-    ].filter((item) => item !== null);
-  };
-
-  const getStatusCodeVariant = (
-    status: string,
-    statusCode?: number,
-  ): "success" | "error" | "pending" => {
-    if (status === "pending") return "pending";
-    if (status === "error") return "error";
-    if (statusCode && statusCode >= 200 && statusCode < 300) return "success";
-    return "error";
   };
 
   return (
@@ -190,216 +91,22 @@ export const NetworkPanel = ({
           scroll-orientation="vertical"
           className={"np-list"}
         >
-          {networks.map((network) => {
-            const activeTab = search.getActiveTab(network.id);
-            return (
-              <list-item key={network.id} item-key={network.id}>
-                <view
-                  className={"np-item"}
-                  style={{
-                    backgroundColor: getItemBg(colors, network.status),
-                    borderBottomColor: colors.stroke.neutralWeak,
-                  }}
-                >
-                  <view
-                    className={"np-itemHeader"}
-                    bindtap={() => toggleExpanded(network.id)}
-                  >
-                    <text
-                      className={"np-method t2"}
-                      style={{
-                        fontWeight: fontWeight.bold,
-                        ...getMethodColors(colors, network.method),
-                      }}
-                    >
-                      {network.method}
-                    </text>
-                    {network.statusCode && (
-                      <text
-                        className={"np-statusCode t2"}
-                        style={{
-                          fontWeight: fontWeight.bold,
-                          color: getStatusCodeColor(
-                            colors,
-                            getStatusCodeVariant(
-                              network.status,
-                              network.statusCode,
-                            ),
-                          ),
-                        }}
-                      >
-                        {network.statusCode}
-                      </text>
-                    )}
-                    {network.status === "pending" && (
-                      <text
-                        className={"np-statusCode t2"}
-                        style={{
-                          fontWeight: fontWeight.bold,
-                          color: colors.fg.neutralSubtle,
-                        }}
-                      >
-                        Pending...
-                      </text>
-                    )}
-                    <text
-                      className={"np-time t2"}
-                      style={{
-                        fontWeight: fontWeight.regular,
-                        color: colors.fg.neutralSubtle,
-                      }}
-                    >
-                      {formatDuration(network.duration)}
-                    </text>
-                    <text
-                      className={"np-time t2"}
-                      style={{
-                        fontWeight: fontWeight.regular,
-                        color: colors.fg.neutralSubtle,
-                      }}
-                    >
-                      {new Date(network.startTime).toISOString()}
-                    </text>
-                  </view>
-
-                  <view bindtap={() => toggleExpanded(network.id)}>
-                    <HighlightText
-                      text={extractPath(network.url)}
-                      query={search.searchQuery}
-                      className={"np-path t3"}
-                      style={{
-                        fontWeight: fontWeight.regular,
-                        color: colors.fg.neutral,
-                      }}
-                    />
-                  </view>
-
-                  {isExpanded(network.id) && (
-                    <view
-                      className={"np-detailsContainer"}
-                      style={{ borderTopColor: colors.stroke.neutralSubtle }}
-                    >
-                      {/* Tabs */}
-                      <view className={"np-tabs"}>
-                        {TABS.map(({ tab, label }) => {
-                          const isActive = activeTab === tab;
-                          return (
-                            <view
-                              key={tab}
-                              className={"np-tab"}
-                              style={{
-                                backgroundColor: isActive
-                                  ? colors.bg.neutralWeak
-                                  : undefined,
-                              }}
-                              bindtap={() => search.selectTab(network.id, tab)}
-                            >
-                              <text
-                                className={"np-tabText t4"}
-                                style={{
-                                  fontWeight: fontWeight.medium,
-                                  color: isActive
-                                    ? colors.fg.neutral
-                                    : colors.fg.neutralSubtle,
-                                }}
-                              >
-                                {label}
-                              </text>
-                            </view>
-                          );
-                        })}
-                      </view>
-
-                      {/* Tab Content */}
-                      <view className={"np-tabContent"}>
-                        {activeTab === "general" && (
-                          <view className={"np-table"}>
-                            {getGeneralInfo(network).map((item) => (
-                              <view
-                                key={item.key}
-                                ref={
-                                  item.key === "URL"
-                                    ? search.getNodeRef(
-                                        network.id,
-                                        matchNode.url,
-                                      )
-                                    : undefined
-                                }
-                                className={"np-tableRow"}
-                                style={{
-                                  backgroundColor: colors.bg.neutralWeak,
-                                }}
-                              >
-                                <text
-                                  className={"np-tableKey t3"}
-                                  style={{
-                                    fontWeight: fontWeight.bold,
-                                    color: colors.fg.neutralSubtle,
-                                  }}
-                                >
-                                  {item.key}
-                                </text>
-                                <HighlightText
-                                  text={item.value}
-                                  query={
-                                    item.key === "URL" ? search.searchQuery : ""
-                                  }
-                                  activeOccurrence={
-                                    item.key === "URL"
-                                      ? search.getActiveOccurrence(
-                                          network.id,
-                                          matchNode.url,
-                                        )
-                                      : -1
-                                  }
-                                  className={"np-tableValue t3"}
-                                  style={{
-                                    fontWeight: fontWeight.regular,
-                                    color: colors.fg.neutral,
-                                  }}
-                                />
-                              </view>
-                            ))}
-                          </view>
-                        )}
-
-                        {activeTab === "request" && (
-                          <NetworkDetailSection
-                            section="request"
-                            headers={network.requestHeaders}
-                            body={network.requestBody}
-                            highlightQuery={search.searchQuery}
-                            getActiveOccurrence={(nodeKey) =>
-                              search.getActiveOccurrence(network.id, nodeKey)
-                            }
-                            getNodeRef={(nodeKey) =>
-                              search.getNodeRef(network.id, nodeKey)
-                            }
-                          />
-                        )}
-
-                        {activeTab === "response" && (
-                          <NetworkDetailSection
-                            section="response"
-                            headers={network.responseHeaders}
-                            body={network.responseBody}
-                            error={network.error}
-                            highlightQuery={search.searchQuery}
-                            getActiveOccurrence={(nodeKey) =>
-                              search.getActiveOccurrence(network.id, nodeKey)
-                            }
-                            getNodeRef={(nodeKey) =>
-                              search.getNodeRef(network.id, nodeKey)
-                            }
-                          />
-                        )}
-                      </view>
-                    </view>
-                  )}
-                </view>
-              </list-item>
-            );
-          })}
+          {networks.map((network) => (
+            <list-item key={network.id} item-key={network.id}>
+              <NetworkListItem
+                network={network}
+                expanded={isExpanded(network.id)}
+                onToggle={() => toggleExpanded(network.id)}
+                activeTab={search.getActiveTab(network.id)}
+                searchQuery={search.searchQuery}
+                onSelectTab={(tab) => search.selectTab(network.id, tab)}
+                getActiveOccurrence={(nodeKey) =>
+                  search.getActiveOccurrence(network.id, nodeKey)
+                }
+                getNodeRef={(nodeKey) => search.getNodeRef(network.id, nodeKey)}
+              />
+            </list-item>
+          ))}
         </list>
       )}
     </view>

--- a/package/src/components/NetworkPanel.tsx
+++ b/package/src/components/NetworkPanel.tsx
@@ -317,6 +317,14 @@ export const NetworkPanel = ({
                             {getGeneralInfo(network).map((item) => (
                               <view
                                 key={item.key}
+                                ref={
+                                  item.key === "URL"
+                                    ? search.getNodeRef(
+                                        network.id,
+                                        matchNode.url,
+                                      )
+                                    : undefined
+                                }
                                 className={"np-tableRow"}
                                 style={{
                                   backgroundColor: colors.bg.neutralWeak,
@@ -364,6 +372,9 @@ export const NetworkPanel = ({
                             getActiveOccurrence={(nodeKey) =>
                               search.getActiveOccurrence(network.id, nodeKey)
                             }
+                            getNodeRef={(nodeKey) =>
+                              search.getNodeRef(network.id, nodeKey)
+                            }
                           />
                         )}
 
@@ -376,6 +387,9 @@ export const NetworkPanel = ({
                             highlightQuery={search.searchQuery}
                             getActiveOccurrence={(nodeKey) =>
                               search.getActiveOccurrence(network.id, nodeKey)
+                            }
+                            getNodeRef={(nodeKey) =>
+                              search.getNodeRef(network.id, nodeKey)
                             }
                           />
                         )}

--- a/package/src/components/NetworkPanel.tsx
+++ b/package/src/components/NetworkPanel.tsx
@@ -336,7 +336,7 @@ export const NetworkPanel = ({
                                     item.key === "URL"
                                       ? search.getActiveOccurrence(
                                           network.id,
-                                          "general",
+                                          "url",
                                         )
                                       : -1
                                   }
@@ -358,7 +358,7 @@ export const NetworkPanel = ({
                             highlightQuery={search.searchQuery}
                             activeOccurrence={search.getActiveOccurrence(
                               network.id,
-                              "request",
+                              "requestBody",
                             )}
                           />
                         )}
@@ -371,7 +371,7 @@ export const NetworkPanel = ({
                             highlightQuery={search.searchQuery}
                             activeOccurrence={search.getActiveOccurrence(
                               network.id,
-                              "response",
+                              "responseBody",
                             )}
                           />
                         )}

--- a/package/src/components/NetworkPanel.tsx
+++ b/package/src/components/NetworkPanel.tsx
@@ -1,5 +1,9 @@
 import { useState } from "@lynx-js/react";
-import { type NetworkTab, useNetworkSearch } from "../hooks/useNetworkSearch";
+import {
+  matchNode,
+  type NetworkTab,
+  useNetworkSearch,
+} from "../hooks/useNetworkSearch";
 import { useThemeColors } from "../styles/ThemeContext";
 import { fontWeight, type ThemeColors } from "../styles/theme";
 import type { NetworkEntry } from "../types";
@@ -336,7 +340,7 @@ export const NetworkPanel = ({
                                     item.key === "URL"
                                       ? search.getActiveOccurrence(
                                           network.id,
-                                          "url",
+                                          matchNode.url,
                                         )
                                       : -1
                                   }
@@ -353,26 +357,26 @@ export const NetworkPanel = ({
 
                         {activeTab === "request" && (
                           <NetworkDetailSection
+                            section="request"
                             headers={network.requestHeaders}
                             body={network.requestBody}
                             highlightQuery={search.searchQuery}
-                            activeOccurrence={search.getActiveOccurrence(
-                              network.id,
-                              "requestBody",
-                            )}
+                            getActiveOccurrence={(nodeKey) =>
+                              search.getActiveOccurrence(network.id, nodeKey)
+                            }
                           />
                         )}
 
                         {activeTab === "response" && (
                           <NetworkDetailSection
+                            section="response"
                             headers={network.responseHeaders}
                             body={network.responseBody}
                             error={network.error}
                             highlightQuery={search.searchQuery}
-                            activeOccurrence={search.getActiveOccurrence(
-                              network.id,
-                              "responseBody",
-                            )}
+                            getActiveOccurrence={(nodeKey) =>
+                              search.getActiveOccurrence(network.id, nodeKey)
+                            }
                           />
                         )}
                       </view>

--- a/package/src/components/NetworkSearchBar.tsx
+++ b/package/src/components/NetworkSearchBar.tsx
@@ -1,0 +1,130 @@
+import type { RefObject } from "@lynx-js/react";
+import type { BaseEvent, InputInputEvent, NodesRef } from "@lynx-js/types";
+import { useThemeColors } from "../styles/ThemeContext";
+import { fontWeight } from "../styles/theme";
+import "./NetworkPanel.css";
+
+interface NetworkSearchBarProps {
+  searchQuery: string;
+  setSearchQuery: (value: string) => void;
+  searchInputRef: RefObject<NodesRef>;
+  totalMatches: number;
+  activeIndex: number;
+  goToMatch: (delta: number) => void;
+  clearNetworks: () => void;
+}
+
+export const NetworkSearchBar = ({
+  searchQuery,
+  setSearchQuery,
+  searchInputRef,
+  totalMatches,
+  activeIndex,
+  goToMatch,
+  clearNetworks,
+}: NetworkSearchBarProps) => {
+  const colors = useThemeColors();
+  const hasQuery = searchQuery.trim().length > 0;
+
+  const clearSearch = () => {
+    setSearchQuery("");
+    searchInputRef.current
+      ?.invoke({ method: "setValue", params: { value: "" } })
+      .exec();
+  };
+
+  return (
+    <view className={"np-header"}>
+      <view
+        className={"np-searchWrapper"}
+        style={{ borderBottomColor: colors.stroke.neutralSubtle }}
+      >
+        <text
+          className={"np-searchPrompt t6"}
+          style={{
+            fontWeight: fontWeight.medium,
+            color: colors.fg.placeholder,
+          }}
+        >
+          {"›"}
+        </text>
+        <input
+          ref={searchInputRef}
+          className={"np-searchInput t3"}
+          style={{
+            fontWeight: fontWeight.regular,
+            color: colors.fg.neutral,
+            caretColor: colors.palette.green600,
+          }}
+          placeholder="Search url, request & response..."
+          bindinput={(e: BaseEvent<"bindinput", InputInputEvent>) =>
+            setSearchQuery(e.detail.value)
+          }
+        />
+        {hasQuery && (
+          <view className={"np-matchNav"}>
+            <text
+              className={"np-matchCount t2"}
+              style={{
+                fontWeight: fontWeight.medium,
+                color: colors.fg.neutralSubtle,
+              }}
+            >
+              {totalMatches > 0 ? `${activeIndex + 1}/${totalMatches}` : "0/0"}
+            </text>
+            {[
+              { delta: -1, icon: "▲" },
+              { delta: 1, icon: "▼" },
+            ].map(({ delta, icon }) => (
+              <view
+                key={icon}
+                className={"np-matchNavButton"}
+                style={{ backgroundColor: colors.bg.neutralWeak }}
+                bindtap={() => goToMatch(delta)}
+              >
+                <text
+                  className={"np-matchNavText t3"}
+                  style={{
+                    fontWeight: fontWeight.bold,
+                    color:
+                      totalMatches > 0
+                        ? colors.fg.neutralMuted
+                        : colors.fg.disabled,
+                  }}
+                >
+                  {icon}
+                </text>
+              </view>
+            ))}
+            <view className={"np-searchClear"} bindtap={clearSearch}>
+              <text
+                className={"np-searchClearText t3"}
+                style={{
+                  fontWeight: fontWeight.medium,
+                  color: colors.fg.placeholder,
+                }}
+              >
+                ✕
+              </text>
+            </view>
+          </view>
+        )}
+      </view>
+      <view
+        className={"np-clearButton"}
+        style={{ backgroundColor: colors.bg.neutralWeak }}
+        bindtap={clearNetworks}
+      >
+        <text
+          className={"np-clearButtonText t3"}
+          style={{
+            fontWeight: fontWeight.medium,
+            color: colors.fg.neutralMuted,
+          }}
+        >
+          🗑
+        </text>
+      </view>
+    </view>
+  );
+};

--- a/package/src/components/NetworkSearchBar.tsx
+++ b/package/src/components/NetworkSearchBar.tsx
@@ -60,6 +60,7 @@ export const NetworkSearchBar = ({
           bindinput={(e: BaseEvent<"bindinput", InputInputEvent>) =>
             setSearchQuery(e.detail.value)
           }
+          bindconfirm={() => goToMatch(1)}
         />
         {hasQuery && (
           <view className={"np-matchNav"}>

--- a/package/src/hooks/useNetworkSearch.ts
+++ b/package/src/hooks/useNetworkSearch.ts
@@ -94,7 +94,9 @@ export function useNetworkSearch(networks: NetworkEntry[]) {
     listRef.current
       ?.invoke({
         method: "scrollToPosition",
-        params: { position: activeEntryIndex, smooth: true },
+        // middle: 매치 항목을 "완전히 보이도록" 화면 중앙에 정렬한다.
+        // top 정렬은 상단 헤더에 가리거나 목록 끝 근처 항목을 못 올리는 문제가 있음
+        params: { position: activeEntryIndex, alignTo: "middle", smooth: true },
         // 스크롤 도중 목록이 갱신되며 나는 무해한 경고를 무시
         fail: () => {},
       })

--- a/package/src/hooks/useNetworkSearch.ts
+++ b/package/src/hooks/useNetworkSearch.ts
@@ -1,0 +1,129 @@
+import { useEffect, useMemo, useRef, useState } from "@lynx-js/react";
+import type { NodesRef } from "@lynx-js/types";
+import { countOccurrences } from "../components/HighlightText";
+import type { NetworkEntry } from "../types";
+
+export type NetworkTab = "general" | "request" | "response";
+
+// 검색어의 개별 등장(매치) 하나
+interface SearchMatch {
+  entryId: string;
+  entryIndex: number;
+  tab: NetworkTab;
+  // 해당 필드 텍스트 안에서의 0-based 등장 순번
+  localIndex: number;
+}
+
+// 패널이 다시 마운트돼도 검색어를 유지
+let savedSearchQuery = "";
+
+/**
+ * 네트워크 패널의 검색 상태와 매치 네비게이션을 담당한다.
+ * url / request body / response body 안의 모든 등장을 평탄한 배열로 모아
+ * 위/아래 이동, 스크롤 포커스, 탭 자동 전환, 활성 매치 강조를 제공한다.
+ */
+export function useNetworkSearch(networks: NetworkEntry[]) {
+  const [searchQuery, setSearchQuery] = useState(savedSearchQuery);
+  // 전체 매치 배열 기준 현재 인덱스(음수/초과는 wrap 처리)
+  const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
+  // 항목별 탭 선택 상태(매치로 이동하거나 직접 탭을 누르면 갱신)
+  const [tabOverrides, setTabOverrides] = useState<Record<string, NetworkTab>>(
+    {},
+  );
+  const searchInputRef = useRef<NodesRef>(null);
+  const listRef = useRef<NodesRef>(null);
+
+  useEffect(() => {
+    savedSearchQuery = searchQuery;
+    // 검색어가 바뀌면 첫 매치부터 다시 시작
+    setCurrentMatchIndex(0);
+  }, [searchQuery]);
+
+  useEffect(() => {
+    if (savedSearchQuery) {
+      searchInputRef.current
+        ?.invoke({ method: "setValue", params: { value: savedSearchQuery } })
+        .exec();
+    }
+  }, []);
+
+  const matches = useMemo<SearchMatch[]>(() => {
+    if (!searchQuery.trim()) return [];
+    const result: SearchMatch[] = [];
+    networks.forEach((network, entryIndex) => {
+      const fields: { tab: NetworkTab; text?: string }[] = [
+        { tab: "general", text: network.url },
+        { tab: "request", text: network.requestBody },
+        { tab: "response", text: network.responseBody },
+      ];
+      for (const { tab, text } of fields) {
+        const count = countOccurrences(text, searchQuery);
+        for (let localIndex = 0; localIndex < count; localIndex++) {
+          result.push({ entryId: network.id, entryIndex, tab, localIndex });
+        }
+      }
+    });
+    return result;
+  }, [networks, searchQuery]);
+
+  const activeIndex =
+    matches.length > 0
+      ? ((currentMatchIndex % matches.length) + matches.length) % matches.length
+      : 0;
+  const activeMatch = matches[activeIndex];
+
+  // 일치한 항목 id 집합과 항목별 기본 탭(첫 매치 기준)
+  const { matchedIds, defaultTabByEntry } = useMemo(() => {
+    const ids = new Set<string>();
+    const tabByEntry = new Map<string, NetworkTab>();
+    for (const match of matches) {
+      ids.add(match.entryId);
+      if (!tabByEntry.has(match.entryId)) {
+        tabByEntry.set(match.entryId, match.tab);
+      }
+    }
+    return { matchedIds: ids, defaultTabByEntry: tabByEntry };
+  }, [matches]);
+
+  // 현재 매치가 바뀌면 해당 항목으로 스크롤하고 그 항목의 탭을 매치 위치로 전환
+  const activeEntryId = activeMatch?.entryId;
+  const activeEntryIndex = activeMatch?.entryIndex;
+  const activeTab = activeMatch?.tab;
+  useEffect(() => {
+    if (activeEntryId === undefined || activeEntryIndex === undefined) return;
+    listRef.current
+      ?.invoke({
+        method: "scrollToPosition",
+        params: { position: activeEntryIndex, smooth: true },
+        // 스크롤 도중 목록이 갱신되며 나는 무해한 경고를 무시
+        fail: () => {},
+      })
+      .exec();
+    if (activeTab) {
+      setTabOverrides((prev) => ({ ...prev, [activeEntryId]: activeTab }));
+    }
+  }, [activeEntryId, activeEntryIndex, activeTab, activeIndex]);
+
+  return {
+    searchQuery,
+    setSearchQuery,
+    searchInputRef,
+    listRef,
+    totalMatches: matches.length,
+    matchedCount: matchedIds.size,
+    activeIndex,
+    isMatched: (id: string): boolean => matchedIds.has(id),
+    getActiveTab: (id: string): NetworkTab =>
+      tabOverrides[id] ?? defaultTabByEntry.get(id) ?? "general",
+    selectTab: (id: string, tab: NetworkTab): void =>
+      setTabOverrides((prev) => ({ ...prev, [id]: tab })),
+    // 이 항목/탭에서 현재 활성 매치의 등장 순번(아니면 -1)
+    getActiveOccurrence: (id: string, tab: NetworkTab): number =>
+      activeMatch && activeMatch.entryId === id && activeMatch.tab === tab
+        ? activeMatch.localIndex
+        : -1,
+    goToMatch: (delta: number): void => {
+      if (matches.length > 0) setCurrentMatchIndex((prev) => prev + delta);
+    },
+  };
+}

--- a/package/src/hooks/useNetworkSearch.ts
+++ b/package/src/hooks/useNetworkSearch.ts
@@ -5,17 +5,38 @@ import type { NetworkEntry } from "../types";
 
 export type NetworkTab = "general" | "request" | "response";
 
+// 검색이 적용되는 개별 필드
+export type MatchField =
+  | "url"
+  | "requestHeaders"
+  | "requestBody"
+  | "responseHeaders"
+  | "responseBody";
+
 // 검색어의 개별 등장(매치) 하나
 interface SearchMatch {
   entryId: string;
   entryIndex: number;
   tab: NetworkTab;
+  field: MatchField;
   // 해당 필드 텍스트 안에서의 0-based 등장 순번
   localIndex: number;
 }
 
 // 패널이 다시 마운트돼도 검색어를 유지
 let savedSearchQuery = "";
+
+// 헤더(key/value)에서 검색어 등장 횟수를 센다(렌더 시 key·value를 각각 강조하므로 합산)
+function countHeaderOccurrences(
+  headers: Record<string, string> | undefined,
+  query: string,
+): number {
+  let count = 0;
+  for (const [key, value] of Object.entries(headers ?? {})) {
+    count += countOccurrences(key, query) + countOccurrences(value, query);
+  }
+  return count;
+}
 
 /**
  * 네트워크 패널의 검색 상태와 매치 네비게이션을 담당한다.
@@ -51,15 +72,42 @@ export function useNetworkSearch(networks: NetworkEntry[]) {
     if (!searchQuery.trim()) return [];
     const result: SearchMatch[] = [];
     networks.forEach((network, entryIndex) => {
-      const fields: { tab: NetworkTab; text?: string }[] = [
-        { tab: "general", text: network.url },
-        { tab: "request", text: network.requestBody },
-        { tab: "response", text: network.responseBody },
+      const fields: { tab: NetworkTab; field: MatchField; count: number }[] = [
+        {
+          tab: "general",
+          field: "url",
+          count: countOccurrences(network.url, searchQuery),
+        },
+        {
+          tab: "request",
+          field: "requestHeaders",
+          count: countHeaderOccurrences(network.requestHeaders, searchQuery),
+        },
+        {
+          tab: "request",
+          field: "requestBody",
+          count: countOccurrences(network.requestBody, searchQuery),
+        },
+        {
+          tab: "response",
+          field: "responseHeaders",
+          count: countHeaderOccurrences(network.responseHeaders, searchQuery),
+        },
+        {
+          tab: "response",
+          field: "responseBody",
+          count: countOccurrences(network.responseBody, searchQuery),
+        },
       ];
-      for (const { tab, text } of fields) {
-        const count = countOccurrences(text, searchQuery);
+      for (const { tab, field, count } of fields) {
         for (let localIndex = 0; localIndex < count; localIndex++) {
-          result.push({ entryId: network.id, entryIndex, tab, localIndex });
+          result.push({
+            entryId: network.id,
+            entryIndex,
+            tab,
+            field,
+            localIndex,
+          });
         }
       }
     });
@@ -120,9 +168,9 @@ export function useNetworkSearch(networks: NetworkEntry[]) {
       tabOverrides[id] ?? defaultTabByEntry.get(id) ?? "general",
     selectTab: (id: string, tab: NetworkTab): void =>
       setTabOverrides((prev) => ({ ...prev, [id]: tab })),
-    // 이 항목/탭에서 현재 활성 매치의 등장 순번(아니면 -1)
-    getActiveOccurrence: (id: string, tab: NetworkTab): number =>
-      activeMatch && activeMatch.entryId === id && activeMatch.tab === tab
+    // 이 항목/필드에서 현재 활성 매치의 등장 순번(아니면 -1)
+    getActiveOccurrence: (id: string, field: MatchField): number =>
+      activeMatch && activeMatch.entryId === id && activeMatch.field === field
         ? activeMatch.localIndex
         : -1,
     goToMatch: (delta: number): void => {

--- a/package/src/hooks/useNetworkSearch.ts
+++ b/package/src/hooks/useNetworkSearch.ts
@@ -130,28 +130,26 @@ export function useNetworkSearch(networks: NetworkEntry[]) {
   const activeEntryId = activeMatch?.entryId;
   const activeEntryIndex = activeMatch?.entryIndex;
   useEffect(() => {
-    if (activeEntryId === undefined) return;
-    if (activeNodeRef.current) {
-      // 매치 노드(헤더 행 등)가 이미 렌더돼 있으면 그 노드를 정확히 상단에 맞춘다
-      activeNodeRef.current
-        .invoke({
-          method: "scrollIntoView",
-          params: {
-            scrollIntoViewOptions: { block: "start", behavior: "smooth" },
-          },
-          fail: () => {},
-        })
-        .exec();
-    } else if (activeEntryIndex !== undefined) {
-      // 아직 렌더 전(가상화로 멀리 있는 항목)이면 항목 단위로 먼저 끌어온다
-      listRef.current
-        ?.invoke({
-          method: "scrollToPosition",
-          params: { position: activeEntryIndex, alignTo: "top", smooth: true },
-          fail: () => {},
-        })
-        .exec();
-    }
+    if (activeEntryId === undefined || activeEntryIndex === undefined) return;
+    // 항목을 상단으로 스크롤(가상화 대응·확실히 동작)
+    listRef.current
+      ?.invoke({
+        method: "scrollToPosition",
+        params: { position: activeEntryIndex, alignTo: "top", smooth: true },
+        // 스크롤 도중 목록이 갱신되며 나는 무해한 경고를 무시
+        fail: () => {},
+      })
+      .exec();
+    // 매치 노드가 렌더돼 있으면 그 노드를 정확히 상단으로 보정(지원 시)
+    activeNodeRef.current
+      ?.invoke({
+        method: "scrollIntoView",
+        params: {
+          scrollIntoViewOptions: { block: "start", behavior: "smooth" },
+        },
+        fail: () => {},
+      })
+      .exec();
   }, [activeEntryId, activeEntryIndex, activeNodeKey, activeIndex]);
 
   return {

--- a/package/src/hooks/useNetworkSearch.ts
+++ b/package/src/hooks/useNetworkSearch.ts
@@ -131,21 +131,44 @@ export function useNetworkSearch(networks: NetworkEntry[]) {
   const activeEntryIndex = activeMatch?.entryIndex;
   useEffect(() => {
     if (activeEntryId === undefined || activeEntryIndex === undefined) return;
-    // 항목을 상단으로 스크롤(가상화 대응·확실히 동작)
+    // 1) 항목을 즉시 상단으로 스크롤(smooth:false → success 콜백 시점에 레이아웃 확정)
     listRef.current
       ?.invoke({
         method: "scrollToPosition",
-        params: { position: activeEntryIndex, alignTo: "top", smooth: true },
-        // 스크롤 도중 목록이 갱신되며 나는 무해한 경고를 무시
-        fail: () => {},
-      })
-      .exec();
-    // 매치 노드가 렌더돼 있으면 그 노드를 정확히 상단으로 보정(지원 시)
-    activeNodeRef.current
-      ?.invoke({
-        method: "scrollIntoView",
-        params: {
-          scrollIntoViewOptions: { block: "start", behavior: "smooth" },
+        params: { index: activeEntryIndex, alignTo: "top", smooth: false },
+        success: () => {
+          const nodeRef = activeNodeRef.current;
+          if (!nodeRef) return;
+          // 2) 매치 노드의 뷰포트 기준 위치 조회
+          nodeRef
+            .invoke({
+              method: "boundingClientRect",
+              params: {},
+              success: (nodeRect) => {
+                // 3) 리스트 자체의 뷰포트 기준 위치 조회
+                listRef.current
+                  ?.invoke({
+                    method: "boundingClientRect",
+                    params: {},
+                    success: (listRect) => {
+                      // 노드가 리스트 상단보다 아래에 있는 만큼 추가 스크롤
+                      const offset = nodeRect.top - listRect.top;
+                      if (offset <= 0) return;
+                      listRef.current
+                        ?.invoke({
+                          method: "scrollBy",
+                          params: { offset },
+                          fail: () => {},
+                        })
+                        .exec();
+                    },
+                    fail: () => {},
+                  })
+                  .exec();
+              },
+              fail: () => {},
+            })
+            .exec();
         },
         fail: () => {},
       })

--- a/package/src/hooks/useNetworkSearch.ts
+++ b/package/src/hooks/useNetworkSearch.ts
@@ -1,4 +1,10 @@
-import { useEffect, useMemo, useRef, useState } from "@lynx-js/react";
+import {
+  type RefObject,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "@lynx-js/react";
 import type { NodesRef } from "@lynx-js/types";
 import { countOccurrences } from "../components/HighlightText";
 import type { NetworkEntry } from "../types";
@@ -46,11 +52,14 @@ export function useNetworkSearch(networks: NetworkEntry[]) {
   );
   const searchInputRef = useRef<NodesRef>(null);
   const listRef = useRef<NodesRef>(null);
+  // 현재 활성 매치가 렌더된 노드(헤더 행 / body 섹션 / url 행)에 붙는 ref
+  const activeNodeRef = useRef<NodesRef>(null);
 
   useEffect(() => {
     savedSearchQuery = searchQuery;
-    // 검색어가 바뀌면 첫 매치부터 다시 시작
+    // 검색어가 바뀌면 첫 매치부터 다시 시작하고 탭 선택도 매치를 따르도록 초기화
     setCurrentMatchIndex(0);
+    setTabOverrides({});
   }, [searchQuery]);
 
   useEffect(() => {
@@ -102,6 +111,7 @@ export function useNetworkSearch(networks: NetworkEntry[]) {
       ? ((currentMatchIndex % matches.length) + matches.length) % matches.length
       : 0;
   const activeMatch = matches[activeIndex];
+  const activeNodeKey = activeMatch?.nodeKey;
 
   // 일치한 항목 id 집합과 항목별 기본 탭(첫 매치 기준)
   const { matchedIds, defaultTabByEntry } = useMemo(() => {
@@ -116,27 +126,33 @@ export function useNetworkSearch(networks: NetworkEntry[]) {
     return { matchedIds: ids, defaultTabByEntry: tabByEntry };
   }, [matches]);
 
-  // 현재 매치가 바뀌면 해당 항목으로 스크롤하고 그 항목의 탭을 매치 위치로 전환
+  // 현재 매치가 바뀌면 매치 노드를 화면 상단으로 스크롤한다.
   const activeEntryId = activeMatch?.entryId;
   const activeEntryIndex = activeMatch?.entryIndex;
-  const activeTab = activeMatch?.tab;
   useEffect(() => {
-    if (activeEntryId === undefined || activeEntryIndex === undefined) return;
-    listRef.current
-      ?.invoke({
-        method: "scrollToPosition",
-        // top: 매치 항목의 맨 위를 검색바 바로 아래로 올린다.
-        // 매치된 body는 NetworkDetailSection에서 Headers보다 위에 렌더되므로
-        // 항목 상단 가까이에 보인다.
-        params: { position: activeEntryIndex, alignTo: "top", smooth: true },
-        // 스크롤 도중 목록이 갱신되며 나는 무해한 경고를 무시
-        fail: () => {},
-      })
-      .exec();
-    if (activeTab) {
-      setTabOverrides((prev) => ({ ...prev, [activeEntryId]: activeTab }));
+    if (activeEntryId === undefined) return;
+    if (activeNodeRef.current) {
+      // 매치 노드(헤더 행 등)가 이미 렌더돼 있으면 그 노드를 정확히 상단에 맞춘다
+      activeNodeRef.current
+        .invoke({
+          method: "scrollIntoView",
+          params: {
+            scrollIntoViewOptions: { block: "start", behavior: "smooth" },
+          },
+          fail: () => {},
+        })
+        .exec();
+    } else if (activeEntryIndex !== undefined) {
+      // 아직 렌더 전(가상화로 멀리 있는 항목)이면 항목 단위로 먼저 끌어온다
+      listRef.current
+        ?.invoke({
+          method: "scrollToPosition",
+          params: { position: activeEntryIndex, alignTo: "top", smooth: true },
+          fail: () => {},
+        })
+        .exec();
     }
-  }, [activeEntryId, activeEntryIndex, activeTab, activeIndex]);
+  }, [activeEntryId, activeEntryIndex, activeNodeKey, activeIndex]);
 
   return {
     searchQuery,
@@ -147,8 +163,12 @@ export function useNetworkSearch(networks: NetworkEntry[]) {
     matchedCount: matchedIds.size,
     activeIndex,
     isMatched: (id: string): boolean => matchedIds.has(id),
+    // 활성 항목은 매치 위치의 탭을 따른다(수동 탭 선택이 있으면 그것을 우선)
     getActiveTab: (id: string): NetworkTab =>
-      tabOverrides[id] ?? defaultTabByEntry.get(id) ?? "general",
+      tabOverrides[id] ??
+      (activeMatch?.entryId === id ? activeMatch.tab : undefined) ??
+      defaultTabByEntry.get(id) ??
+      "general",
     selectTab: (id: string, tab: NetworkTab): void =>
       setTabOverrides((prev) => ({ ...prev, [id]: tab })),
     // 이 항목/노드에서 현재 활성 매치의 등장 순번(아니면 -1)
@@ -158,8 +178,21 @@ export function useNetworkSearch(networks: NetworkEntry[]) {
       activeMatch.nodeKey === nodeKey
         ? activeMatch.localIndex
         : -1,
+    // 활성 매치 노드에만 스크롤용 ref를 부여한다(나머지는 undefined)
+    getNodeRef: (
+      id: string,
+      nodeKey: string,
+    ): RefObject<NodesRef> | undefined =>
+      activeMatch &&
+      activeMatch.entryId === id &&
+      activeMatch.nodeKey === nodeKey
+        ? activeNodeRef
+        : undefined,
     goToMatch: (delta: number): void => {
-      if (matches.length > 0) setCurrentMatchIndex((prev) => prev + delta);
+      if (matches.length === 0) return;
+      // 이동 시 탭 선택을 비워 활성 항목이 매치 위치의 탭을 따르도록 한다
+      setTabOverrides({});
+      setCurrentMatchIndex((prev) => prev + delta);
     },
   };
 }

--- a/package/src/hooks/useNetworkSearch.ts
+++ b/package/src/hooks/useNetworkSearch.ts
@@ -157,6 +157,8 @@ export function useNetworkSearch(networks: NetworkEntry[]) {
     // 빠른 연속 이동 시 이미 다른 노드를 가리킬 수 있다
     const nodeRef = activeNodeRef.current;
     const listNode = listRef.current;
+    // 다음 매치로 빠르게 이동하면 이전 체인을 중단해 옛 스크롤이 이기지 않게 한다
+    let cancelled = false;
 
     void (async () => {
       try {
@@ -166,12 +168,13 @@ export function useNetworkSearch(networks: NetworkEntry[]) {
           alignTo: "top",
           smooth: false,
         });
-        if (!nodeRef) return;
+        if (cancelled || !nodeRef) return;
         // 2) 매치 노드와 리스트의 뷰포트 기준 위치를 병렬 조회
         const [nodeRect, listRect] = await Promise.all([
           invokeAsync<{ top: number }>(nodeRef, "boundingClientRect"),
           invokeAsync<{ top: number }>(listNode, "boundingClientRect"),
         ]);
+        if (cancelled) return;
         // 3) 노드가 리스트 상단보다 아래에 있는 만큼 추가 스크롤
         const offset = nodeRect.top - listRect.top;
         if (offset <= 0) return;
@@ -180,6 +183,10 @@ export function useNetworkSearch(networks: NetworkEntry[]) {
         // 스크롤 실패(언마운트·ref 없음 등)는 무시
       }
     })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [activeEntryId, activeEntryIndex, activeNodeKey, activeIndex]);
 
   return {

--- a/package/src/hooks/useNetworkSearch.ts
+++ b/package/src/hooks/useNetworkSearch.ts
@@ -8,28 +8,7 @@ import {
 import type { NodesRef } from "@lynx-js/types";
 import { countOccurrences } from "../components/HighlightText";
 import type { NetworkEntry } from "../types";
-
-// Lynx invoke 콜백을 Promise로 래핑 — 콜백 중첩 없이 await로 순차 호출 가능
-function invokeAsync<T = void>(
-  ref: NodesRef | null | undefined,
-  method: string,
-  params?: Record<string, unknown>,
-): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    if (!ref) {
-      reject(new Error("ref is null"));
-      return;
-    }
-    ref
-      .invoke({
-        method,
-        params,
-        success: (res: T) => resolve(res),
-        fail: () => reject(new Error("invoke failed")),
-      })
-      .exec();
-  });
-}
+import { useScrollToActiveMatch } from "./useScrollToActiveMatch";
 
 export type NetworkTab = "general" | "request" | "response";
 type Section = "request" | "response";
@@ -133,7 +112,6 @@ export function useNetworkSearch(networks: NetworkEntry[]) {
       ? ((currentMatchIndex % matches.length) + matches.length) % matches.length
       : 0;
   const activeMatch = matches[activeIndex];
-  const activeNodeKey = activeMatch?.nodeKey;
 
   // 일치한 항목 id 집합과 항목별 기본 탭(첫 매치 기준)
   const { matchedIds, defaultTabByEntry } = useMemo(() => {
@@ -148,46 +126,20 @@ export function useNetworkSearch(networks: NetworkEntry[]) {
     return { matchedIds: ids, defaultTabByEntry: tabByEntry };
   }, [matches]);
 
-  // 현재 매치가 바뀌면 매치 노드를 화면 상단으로 스크롤한다.
-  const activeEntryId = activeMatch?.entryId;
-  const activeEntryIndex = activeMatch?.entryIndex;
-  useEffect(() => {
-    if (activeEntryId === undefined || activeEntryIndex === undefined) return;
-    // effect 시작 시점에 스냅샷 캡처 — 비동기 콜백 내부에서 읽으면
-    // 빠른 연속 이동 시 이미 다른 노드를 가리킬 수 있다
-    const nodeRef = activeNodeRef.current;
-    const listNode = listRef.current;
-    // 다음 매치로 빠르게 이동하면 이전 체인을 중단해 옛 스크롤이 이기지 않게 한다
-    let cancelled = false;
-
-    void (async () => {
-      try {
-        // 1) 항목을 즉시 상단으로 스크롤(smooth:false → 완료 후 레이아웃 확정)
-        await invokeAsync(listNode, "scrollToPosition", {
-          index: activeEntryIndex,
-          alignTo: "top",
-          smooth: false,
-        });
-        if (cancelled || !nodeRef) return;
-        // 2) 매치 노드와 리스트의 뷰포트 기준 위치를 병렬 조회
-        const [nodeRect, listRect] = await Promise.all([
-          invokeAsync<{ top: number }>(nodeRef, "boundingClientRect"),
-          invokeAsync<{ top: number }>(listNode, "boundingClientRect"),
-        ]);
-        if (cancelled) return;
-        // 3) 노드가 리스트 상단보다 아래에 있는 만큼 추가 스크롤
-        const offset = nodeRect.top - listRect.top;
-        if (offset <= 0) return;
-        await invokeAsync(listNode, "scrollBy", { offset });
-      } catch {
-        // 스크롤 실패(언마운트·ref 없음 등)는 무시
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [activeEntryId, activeEntryIndex, activeNodeKey, activeIndex]);
+  // 활성 매치가 바뀌면 그 노드를 리스트 상단으로 스크롤한다(상세 전략은 훅 참고)
+  useScrollToActiveMatch(
+    listRef,
+    activeNodeRef,
+    activeMatch
+      ? {
+          entryId: activeMatch.entryId,
+          entryIndex: activeMatch.entryIndex,
+          tab: activeMatch.tab,
+          nodeKey: activeMatch.nodeKey,
+          index: activeIndex,
+        }
+      : null,
+  );
 
   return {
     searchQuery,

--- a/package/src/hooks/useNetworkSearch.ts
+++ b/package/src/hooks/useNetworkSearch.ts
@@ -94,9 +94,10 @@ export function useNetworkSearch(networks: NetworkEntry[]) {
     listRef.current
       ?.invoke({
         method: "scrollToPosition",
-        // middle: 매치 항목을 "완전히 보이도록" 화면 중앙에 정렬한다.
-        // top 정렬은 상단 헤더에 가리거나 목록 끝 근처 항목을 못 올리는 문제가 있음
-        params: { position: activeEntryIndex, alignTo: "middle", smooth: true },
+        // top: 매치 항목의 맨 위를 검색바 바로 아래로 올린다.
+        // 매치된 body는 NetworkDetailSection에서 Headers보다 위에 렌더되므로
+        // 항목 상단 가까이에 보인다.
+        params: { position: activeEntryIndex, alignTo: "top", smooth: true },
         // 스크롤 도중 목록이 갱신되며 나는 무해한 경고를 무시
         fail: () => {},
       })

--- a/package/src/hooks/useNetworkSearch.ts
+++ b/package/src/hooks/useNetworkSearch.ts
@@ -4,44 +4,37 @@ import { countOccurrences } from "../components/HighlightText";
 import type { NetworkEntry } from "../types";
 
 export type NetworkTab = "general" | "request" | "response";
+type Section = "request" | "response";
 
-// 검색이 적용되는 개별 필드
-export type MatchField =
-  | "url"
-  | "requestHeaders"
-  | "requestBody"
-  | "responseHeaders"
-  | "responseBody";
+// 렌더되는 개별 <text> 노드를 고유 식별하는 키 생성기.
+// 훅(매치 카운트)과 렌더(강조)가 반드시 같은 키를 쓰도록 한곳에서 관리한다.
+export const matchNode = {
+  url: "url",
+  body: (section: Section): string => `${section}:body`,
+  headerKey: (section: Section, name: string): string =>
+    `${section}:hdr:${name}:k`,
+  headerValue: (section: Section, name: string): string =>
+    `${section}:hdr:${name}:v`,
+};
 
 // 검색어의 개별 등장(매치) 하나
 interface SearchMatch {
   entryId: string;
   entryIndex: number;
   tab: NetworkTab;
-  field: MatchField;
-  // 해당 필드 텍스트 안에서의 0-based 등장 순번
+  // 렌더되는 <text> 노드 식별자(matchNode로 생성)
+  nodeKey: string;
+  // 그 노드 텍스트 안에서의 0-based 등장 순번
   localIndex: number;
 }
 
 // 패널이 다시 마운트돼도 검색어를 유지
 let savedSearchQuery = "";
 
-// 헤더(key/value)에서 검색어 등장 횟수를 센다(렌더 시 key·value를 각각 강조하므로 합산)
-function countHeaderOccurrences(
-  headers: Record<string, string> | undefined,
-  query: string,
-): number {
-  let count = 0;
-  for (const [key, value] of Object.entries(headers ?? {})) {
-    count += countOccurrences(key, query) + countOccurrences(value, query);
-  }
-  return count;
-}
-
 /**
  * 네트워크 패널의 검색 상태와 매치 네비게이션을 담당한다.
- * url / request body / response body 안의 모든 등장을 평탄한 배열로 모아
- * 위/아래 이동, 스크롤 포커스, 탭 자동 전환, 활성 매치 강조를 제공한다.
+ * url / request·response 헤더 / request·response body 안의 모든 등장을
+ * 노드 단위로 모아 위/아래 이동, 스크롤 포커스, 탭 전환, 활성 매치 강조를 제공한다.
  */
 export function useNetworkSearch(networks: NetworkEntry[]) {
   const [searchQuery, setSearchQuery] = useState(savedSearchQuery);
@@ -72,44 +65,34 @@ export function useNetworkSearch(networks: NetworkEntry[]) {
     if (!searchQuery.trim()) return [];
     const result: SearchMatch[] = [];
     networks.forEach((network, entryIndex) => {
-      const fields: { tab: NetworkTab; field: MatchField; count: number }[] = [
-        {
-          tab: "general",
-          field: "url",
-          count: countOccurrences(network.url, searchQuery),
-        },
-        {
-          tab: "request",
-          field: "requestHeaders",
-          count: countHeaderOccurrences(network.requestHeaders, searchQuery),
-        },
-        {
-          tab: "request",
-          field: "requestBody",
-          count: countOccurrences(network.requestBody, searchQuery),
-        },
-        {
-          tab: "response",
-          field: "responseHeaders",
-          count: countHeaderOccurrences(network.responseHeaders, searchQuery),
-        },
-        {
-          tab: "response",
-          field: "responseBody",
-          count: countOccurrences(network.responseBody, searchQuery),
-        },
-      ];
-      for (const { tab, field, count } of fields) {
+      // 렌더 순서와 동일하게 노드를 훑으며 각 노드의 등장마다 매치를 만든다
+      const addNode = (tab: NetworkTab, nodeKey: string, text?: string) => {
+        const count = countOccurrences(text, searchQuery);
         for (let localIndex = 0; localIndex < count; localIndex++) {
           result.push({
             entryId: network.id,
             entryIndex,
             tab,
-            field,
+            nodeKey,
             localIndex,
           });
         }
-      }
+      };
+      const addHeaders = (
+        section: Section,
+        headers?: Record<string, string>,
+      ) => {
+        for (const [key, value] of Object.entries(headers ?? {})) {
+          addNode(section, matchNode.headerKey(section, key), key);
+          addNode(section, matchNode.headerValue(section, key), value);
+        }
+      };
+
+      addNode("general", matchNode.url, network.url);
+      addHeaders("request", network.requestHeaders);
+      addNode("request", matchNode.body("request"), network.requestBody);
+      addHeaders("response", network.responseHeaders);
+      addNode("response", matchNode.body("response"), network.responseBody);
     });
     return result;
   }, [networks, searchQuery]);
@@ -168,9 +151,11 @@ export function useNetworkSearch(networks: NetworkEntry[]) {
       tabOverrides[id] ?? defaultTabByEntry.get(id) ?? "general",
     selectTab: (id: string, tab: NetworkTab): void =>
       setTabOverrides((prev) => ({ ...prev, [id]: tab })),
-    // 이 항목/필드에서 현재 활성 매치의 등장 순번(아니면 -1)
-    getActiveOccurrence: (id: string, field: MatchField): number =>
-      activeMatch && activeMatch.entryId === id && activeMatch.field === field
+    // 이 항목/노드에서 현재 활성 매치의 등장 순번(아니면 -1)
+    getActiveOccurrence: (id: string, nodeKey: string): number =>
+      activeMatch &&
+      activeMatch.entryId === id &&
+      activeMatch.nodeKey === nodeKey
         ? activeMatch.localIndex
         : -1,
     goToMatch: (delta: number): void => {

--- a/package/src/hooks/useNetworkSearch.ts
+++ b/package/src/hooks/useNetworkSearch.ts
@@ -131,14 +131,17 @@ export function useNetworkSearch(networks: NetworkEntry[]) {
   const activeEntryIndex = activeMatch?.entryIndex;
   useEffect(() => {
     if (activeEntryId === undefined || activeEntryIndex === undefined) return;
+    // effect 시작 시점의 노드를 스냅샷으로 캡처 — 콜백 내부에서 읽으면
+    // 빠른 연속 이동 시 이미 다른 노드를 가리킬 수 있다
+    const nodeRef = activeNodeRef.current;
     // 1) 항목을 즉시 상단으로 스크롤(smooth:false → success 콜백 시점에 레이아웃 확정)
     listRef.current
       ?.invoke({
         method: "scrollToPosition",
         params: { index: activeEntryIndex, alignTo: "top", smooth: false },
         success: () => {
-          const nodeRef = activeNodeRef.current;
           if (!nodeRef) return;
+
           // 2) 매치 노드의 뷰포트 기준 위치 조회
           nodeRef
             .invoke({

--- a/package/src/hooks/useNetworkSearch.ts
+++ b/package/src/hooks/useNetworkSearch.ts
@@ -9,6 +9,28 @@ import type { NodesRef } from "@lynx-js/types";
 import { countOccurrences } from "../components/HighlightText";
 import type { NetworkEntry } from "../types";
 
+// Lynx invoke 콜백을 Promise로 래핑 — 콜백 중첩 없이 await로 순차 호출 가능
+function invokeAsync<T = void>(
+  ref: NodesRef | null | undefined,
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    if (!ref) {
+      reject(new Error("ref is null"));
+      return;
+    }
+    ref
+      .invoke({
+        method,
+        params,
+        success: (res: T) => resolve(res),
+        fail: () => reject(new Error("invoke failed")),
+      })
+      .exec();
+  });
+}
+
 export type NetworkTab = "general" | "request" | "response";
 type Section = "request" | "response";
 
@@ -131,51 +153,33 @@ export function useNetworkSearch(networks: NetworkEntry[]) {
   const activeEntryIndex = activeMatch?.entryIndex;
   useEffect(() => {
     if (activeEntryId === undefined || activeEntryIndex === undefined) return;
-    // effect 시작 시점의 노드를 스냅샷으로 캡처 — 콜백 내부에서 읽으면
+    // effect 시작 시점에 스냅샷 캡처 — 비동기 콜백 내부에서 읽으면
     // 빠른 연속 이동 시 이미 다른 노드를 가리킬 수 있다
     const nodeRef = activeNodeRef.current;
-    // 1) 항목을 즉시 상단으로 스크롤(smooth:false → success 콜백 시점에 레이아웃 확정)
-    listRef.current
-      ?.invoke({
-        method: "scrollToPosition",
-        params: { index: activeEntryIndex, alignTo: "top", smooth: false },
-        success: () => {
-          if (!nodeRef) return;
+    const listNode = listRef.current;
 
-          // 2) 매치 노드의 뷰포트 기준 위치 조회
-          nodeRef
-            .invoke({
-              method: "boundingClientRect",
-              params: {},
-              success: (nodeRect) => {
-                // 3) 리스트 자체의 뷰포트 기준 위치 조회
-                listRef.current
-                  ?.invoke({
-                    method: "boundingClientRect",
-                    params: {},
-                    success: (listRect) => {
-                      // 노드가 리스트 상단보다 아래에 있는 만큼 추가 스크롤
-                      const offset = nodeRect.top - listRect.top;
-                      if (offset <= 0) return;
-                      listRef.current
-                        ?.invoke({
-                          method: "scrollBy",
-                          params: { offset },
-                          fail: () => {},
-                        })
-                        .exec();
-                    },
-                    fail: () => {},
-                  })
-                  .exec();
-              },
-              fail: () => {},
-            })
-            .exec();
-        },
-        fail: () => {},
-      })
-      .exec();
+    void (async () => {
+      try {
+        // 1) 항목을 즉시 상단으로 스크롤(smooth:false → 완료 후 레이아웃 확정)
+        await invokeAsync(listNode, "scrollToPosition", {
+          index: activeEntryIndex,
+          alignTo: "top",
+          smooth: false,
+        });
+        if (!nodeRef) return;
+        // 2) 매치 노드와 리스트의 뷰포트 기준 위치를 병렬 조회
+        const [nodeRect, listRect] = await Promise.all([
+          invokeAsync<{ top: number }>(nodeRef, "boundingClientRect"),
+          invokeAsync<{ top: number }>(listNode, "boundingClientRect"),
+        ]);
+        // 3) 노드가 리스트 상단보다 아래에 있는 만큼 추가 스크롤
+        const offset = nodeRect.top - listRect.top;
+        if (offset <= 0) return;
+        await invokeAsync(listNode, "scrollBy", { offset });
+      } catch {
+        // 스크롤 실패(언마운트·ref 없음 등)는 무시
+      }
+    })();
   }, [activeEntryId, activeEntryIndex, activeNodeKey, activeIndex]);
 
   return {

--- a/package/src/hooks/useScrollToActiveMatch.ts
+++ b/package/src/hooks/useScrollToActiveMatch.ts
@@ -1,0 +1,100 @@
+import { type RefObject, useEffect, useRef } from "@lynx-js/react";
+import type { NodesRef } from "@lynx-js/types";
+import { invokeAsync } from "../utils/invokeAsync";
+import type { NetworkTab } from "./useNetworkSearch";
+
+// 스크롤 대상 매치의 위치 정보(null이면 스크롤하지 않음)
+export interface ScrollTarget {
+  entryId: string;
+  entryIndex: number;
+  tab: NetworkTab;
+  // 노드/순번이 바뀔 때도 재스크롤하도록 effect 의존성에 쓰인다
+  nodeKey: string;
+  index: number;
+}
+
+// 매치 노드를 리스트 상단에 맞춘다(위/아래 모두 한 번의 scrollBy로 보정).
+// 노드가 렌더돼 있고 레이아웃이 끝나야 boundingClientRect가 정확하므로,
+// 측정 가능할 때만 보정하고 그렇지 못하면(가상화로 미렌더) false를 반환한다.
+async function alignNodeToTop(
+  listNode: NodesRef | null,
+  nodeRef: NodesRef | null,
+  isCancelled: () => boolean,
+): Promise<boolean> {
+  if (!nodeRef) return false;
+  const [nodeRect, listRect] = await Promise.all([
+    invokeAsync<{ top: number }>(nodeRef, "boundingClientRect"),
+    invokeAsync<{ top: number }>(listNode, "boundingClientRect"),
+  ]);
+  if (isCancelled()) return true;
+  const offset = nodeRect.top - listRect.top;
+  if (Math.abs(offset) > 1) {
+    await invokeAsync(listNode, "scrollBy", { offset });
+  }
+  return true;
+}
+
+/**
+ * 활성 매치가 바뀔 때 그 노드를 리스트 상단으로 스크롤한다.
+ *
+ * - 같은 항목·같은 탭 안에서의 이동: 레이아웃이 이미 안정적이라 단일
+ *   scrollBy로 부드럽게 정렬한다(중간 점프 없음 → 깜빡임 없음).
+ * - 항목이나 탭이 바뀌는 이동: 헤더 펼침 등으로 레이아웃이 새로 잡히는데,
+ *   그 직후의 boundingClientRect는 펼쳐지기 전 좌표를 줄 수 있어 측정이
+ *   빗나간다. 그래서 먼저 scrollToPosition으로 항목을 상단에 올려 레이아웃을
+ *   확정한 뒤 보정한다(2단계 — 한 번 점프해 보이지만 확실하다).
+ */
+export function useScrollToActiveMatch(
+  listRef: RefObject<NodesRef>,
+  activeNodeRef: RefObject<NodesRef>,
+  target: ScrollTarget | null,
+): void {
+  // 직전에 스크롤한 항목/탭 — 같은 컨텍스트면 단일 scrollBy로 갈 수 있다
+  const lastCtxRef = useRef<{ entryId: string; tab: NetworkTab } | null>(null);
+
+  const { entryId, entryIndex, tab, nodeKey, index } = target ?? {};
+
+  useEffect(() => {
+    if (
+      entryId === undefined ||
+      entryIndex === undefined ||
+      tab === undefined
+    ) {
+      return;
+    }
+    const listNode = listRef.current;
+    let cancelled = false;
+    const isCancelled = () => cancelled;
+
+    const last = lastCtxRef.current;
+    const sameContext =
+      last !== null && last.entryId === entryId && last.tab === tab;
+    lastCtxRef.current = { entryId, tab };
+
+    void (async () => {
+      try {
+        // 같은 탭 내 이동: 단일 scrollBy
+        if (
+          sameContext &&
+          (await alignNodeToTop(listNode, activeNodeRef.current, isCancelled))
+        ) {
+          return;
+        }
+        // 탭/항목 변경: 항목을 상단으로 올려 레이아웃 확정 후 보정(2단계)
+        await invokeAsync(listNode, "scrollToPosition", {
+          index: entryIndex,
+          alignTo: "top",
+          smooth: false,
+        });
+        if (cancelled) return;
+        await alignNodeToTop(listNode, activeNodeRef.current, isCancelled);
+      } catch {
+        // 스크롤 실패(언마운트·ref 없음 등)는 무시
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [listRef, activeNodeRef, entryId, entryIndex, tab, nodeKey, index]);
+}

--- a/package/src/styles/theme.ts
+++ b/package/src/styles/theme.ts
@@ -35,6 +35,13 @@ const lightColors = {
     neutralSubtle: "#0000000c",
     neutralWeak: "#dcdee3",
   },
+  // 검색 하이라이트(버터·살구). match=전체 매치, active=현재 선택된 매치
+  highlight: {
+    matchBg: "#fef3c7",
+    matchText: "#92400e",
+    activeBg: "#fcd34d",
+    activeText: "#78350f",
+  },
 } as const;
 
 const darkColors = {
@@ -71,6 +78,13 @@ const darkColors = {
   stroke: {
     neutralSubtle: "#ffffff0d",
     neutralWeak: "#393d46",
+  },
+  // 검색 하이라이트(버터·살구). match=전체 매치, active=현재 선택된 매치
+  highlight: {
+    matchBg: "#46401d",
+    matchText: "#fde68a",
+    activeBg: "#b7791f",
+    activeText: "#fff7e0",
   },
 } as const;
 

--- a/package/src/utils/invokeAsync.ts
+++ b/package/src/utils/invokeAsync.ts
@@ -1,0 +1,23 @@
+import type { NodesRef } from "@lynx-js/types";
+
+// Lynx invoke 콜백을 Promise로 래핑 — 콜백 중첩 없이 await로 순차 호출 가능
+export function invokeAsync<T = void>(
+  ref: NodesRef | null | undefined,
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    if (!ref) {
+      reject(new Error("ref is null"));
+      return;
+    }
+    ref
+      .invoke({
+        method,
+        params,
+        success: (res: T) => resolve(res),
+        fail: () => reject(new Error("invoke failed")),
+      })
+      .exec();
+  });
+}

--- a/package/src/utils/networkFormat.ts
+++ b/package/src/utils/networkFormat.ts
@@ -1,0 +1,121 @@
+import type { NetworkTab } from "../hooks/useNetworkSearch";
+import type { ThemeColors } from "../styles/theme";
+import type { NetworkEntry } from "../types";
+
+export const TABS: { tab: NetworkTab; label: string }[] = [
+  { tab: "general", label: "General" },
+  { tab: "request", label: "Request" },
+  { tab: "response", label: "Response" },
+];
+
+export function getMethodColors(colors: ThemeColors, method: string) {
+  switch (method) {
+    case "GET":
+      return {
+        color: colors.palette.blue600,
+        backgroundColor: colors.palette.blue100,
+      };
+    case "POST":
+      return {
+        color: colors.palette.green600,
+        backgroundColor: colors.palette.green100,
+      };
+    case "PUT":
+      return {
+        color: colors.palette.yellow600,
+        backgroundColor: colors.palette.yellow100,
+      };
+    case "PATCH":
+      return {
+        color: colors.palette.purple600,
+        backgroundColor: colors.palette.purple100,
+      };
+    case "DELETE":
+      return {
+        color: colors.palette.red600,
+        backgroundColor: colors.palette.red100,
+      };
+    default:
+      return {
+        color: colors.fg.neutral,
+        backgroundColor: colors.bg.neutralWeak,
+      };
+  }
+}
+
+export function getStatusCodeColor(
+  colors: ThemeColors,
+  variant: "success" | "error" | "pending",
+): string {
+  switch (variant) {
+    case "success":
+      return colors.palette.green600;
+    case "error":
+      return colors.palette.red600;
+    case "pending":
+      return colors.fg.neutralSubtle;
+  }
+}
+
+export function getStatusCodeVariant(
+  status: string,
+  statusCode?: number,
+): "success" | "error" | "pending" {
+  if (status === "pending") return "pending";
+  if (status === "error") return "error";
+  if (statusCode && statusCode >= 200 && statusCode < 300) return "success";
+  return "error";
+}
+
+export function getItemBg(
+  colors: ThemeColors,
+  status: string,
+): string | undefined {
+  switch (status) {
+    case "pending":
+      return colors.palette.gray100;
+    case "error":
+      return colors.palette.red100;
+    default:
+      return undefined;
+  }
+}
+
+export function formatDuration(duration?: number): string {
+  if (!duration) return "-";
+  if (duration < 1000) return `${duration}ms`;
+  return `${(duration / 1000).toFixed(2)}s`;
+}
+
+export function extractPath(url: string): string {
+  const pathMatch = url.match(/^https?:\/\/[^/]+(.*)$/);
+  if (pathMatch?.[1]) {
+    return pathMatch[1].startsWith("/") ? pathMatch[1].slice(1) : pathMatch[1];
+  }
+  return url;
+}
+
+export function getGeneralInfo(
+  network: NetworkEntry,
+): { key: string; value: string }[] {
+  return [
+    { key: "URL", value: network.url },
+    { key: "Method", value: network.method },
+    network.statusCode
+      ? { key: "Status", value: String(network.statusCode) }
+      : null,
+    {
+      key: "Request Time",
+      value: new Date(network.startTime).toISOString(),
+    },
+    network.endTime
+      ? {
+          key: "Response Time",
+          value: new Date(network.endTime).toISOString(),
+        }
+      : null,
+    network.duration
+      ? { key: "Duration", value: formatDuration(network.duration) }
+      : null,
+  ].filter((item) => item !== null);
+}


### PR DESCRIPTION

https://github.com/user-attachments/assets/e66e9e0f-6f48-479f-8c56-58eab7bf71cd

## 요약
네트워크 탭에 검색 기능을 추가해요. URL · 헤더 · request/response body에서 검색하고, 매치를 하이라이팅하면서 해당 요청 안의 정확한 위치로 스크롤해요. 브라우저 찾기(Ctrl+F)처럼 개별 매치 사이를 ▲/▼(또는 엔터)로 이동할 수 있어요.

## 기능
- **검색 대상**: 요청 URL, request/response 헤더(key·value), request/response body (대소문자 무시)
- **하이라이팅**: 현재 선택 매치는 진한 색(버터·살구 파스텔), 나머지는 옅은 색으로 구분
- **자동 펼침/탭 전환**: 매치가 있는 항목을 펼치고, 매치 위치의 탭(General/Request/Response)으로 전환
- **헤더 토글**: 헤더는 기본 접힘 — 매치가 있을 때만 자동으로 펼침. 사용자가 직접 토글도 가능
- **매치 항목 접기**: 매치로 자동 펼쳐진 항목도 탭하면 접혀요(검색 외에는 단일 아코디언)
- **매치 네비게이션**: ▲/▼ 또는 엔터로 순환 이동, `현재/전체` 카운터
- **정밀 스크롤**: 매치 노드(헤더 행 포함)를 리스트 상단에 정확히 정렬

## 구조
- `useNetworkSearch` 훅 — 검색 상태, 매치 배열, 네비게이션
- `useScrollToActiveMatch` 훅 — 활성 매치로의 스크롤 전략(아래 참고)
- `NetworkSearchBar` / `NetworkListItem` / `NetworkGeneralSection` / `NetworkDetailSection` — 검색 UI와 항목·탭 렌더
- `HighlightText` — 매치 강조(`matchIndices` 단일 출처로 카운트/강조 일치)
- `utils/networkFormat` · `utils/invokeAsync` — 순수 포맷 함수, Lynx invoke→Promise 래퍼

## 스크롤 구현 (Lynx `<list>` 제약 대응)
`<list>`는 항목 단위 가상화라 `scrollIntoView`가 내부 자식 노드에 전파되지 않아요. 그래서 상황에 따라 두 전략을 나눠 써요:

- **같은 항목·같은 탭 내 이동**: 레이아웃이 안정적이라 `boundingClientRect`로 보정량을 재서 **단일 `scrollBy`** 한 번으로 정렬 → 깜빡임 없음
- **탭/항목이 바뀌는 이동**: 헤더 펼침 등으로 레이아웃이 새로 잡히는데, 그 직후의 `boundingClientRect`는 펼쳐지기 전 좌표를 줄 수 있어 측정이 빗나가요. 그래서 먼저 `scrollToPosition`으로 항목을 상단에 올려 레이아웃을 확정한 뒤 보정하는 **2단계**를 써요

## 검증
- tsc / biome / build 통과
- 실기기 동작 확인 필요
