### PR TITLE
feat: add log button to network request/response body

### DIFF
--- a/.changeset/log-body-button.md
+++ b/.changeset/log-body-button.md
@@ -1,0 +1,5 @@
+---
+"lynx-console": patch
+---
+
+Add a log button to the request/response body section in the Network panel. Tapping it prints the body to console.log, useful for copying body content via Lynx DevTool in environments where clipboard access is unavailable.

--- a/package/src/components/NetworkDetailSection.tsx
+++ b/package/src/components/NetworkDetailSection.tsx
@@ -30,7 +30,7 @@ export const NetworkDetailSection = ({
   getNodeRef = () => undefined,
 }: NetworkDetailSectionProps) => {
   const colors = useThemeColors();
-  const [isLogged, setIsLogged] = useState(false);
+  const [showLogConfirm, setShowLogConfirm] = useState(false);
 
   // 헤더 행 안의 key 또는 value가 활성 매치면 그 행에 스크롤 ref를 단다
   const rowRef = (name: string) =>
@@ -148,18 +148,18 @@ export const NetworkDetailSection = ({
               }}
               bindtap={() => {
                 console.log(`[lynx-console] ${section} body:`, body);
-                setIsLogged(true);
-                setTimeout(() => setIsLogged(false), 5000);
+                setShowLogConfirm(true);
+                setTimeout(() => setShowLogConfirm(false), 5000);
               }}
             >
               <text
                 className={"t3"}
                 style={{
-                  color: isLogged ? colors.fg.accent : colors.fg.neutralSubtle,
+                  color: showLogConfirm ? colors.fg.accent : colors.fg.neutralSubtle,
                   fontWeight: fontWeight.regular,
                 }}
               >
-                {isLogged ? "✓ logged" : "log"}
+                {showLogConfirm ? "✓ logged" : "log"}
               </text>
             </view>
           )}

--- a/package/src/components/NetworkDetailSection.tsx
+++ b/package/src/components/NetworkDetailSection.tsx
@@ -1,4 +1,4 @@
-import { type RefObject, useState, useRef } from "@lynx-js/react";
+import { type RefObject, useState } from "@lynx-js/react";
 import type { NodesRef } from "@lynx-js/types";
 import { matchNode } from "../hooks/useNetworkSearch";
 import { useThemeColors } from "../styles/ThemeContext";
@@ -31,7 +31,6 @@ export const NetworkDetailSection = ({
 }: NetworkDetailSectionProps) => {
   const colors = useThemeColors();
   const [toastVisible, setToastVisible] = useState(false);
-  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // 헤더 행 안의 key 또는 value가 활성 매치면 그 행에 스크롤 ref를 단다
   const rowRef = (name: string) =>
@@ -149,9 +148,8 @@ export const NetworkDetailSection = ({
               }}
               bindtap={() => {
                 console.log(`[lynx-console] ${section} body:`, body);
-                if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
                 setToastVisible(true);
-                toastTimerRef.current = setTimeout(() => setToastVisible(false), 5000);
+                setTimeout(() => setToastVisible(false), 5000);
               }}
             >
               <text

--- a/package/src/components/NetworkDetailSection.tsx
+++ b/package/src/components/NetworkDetailSection.tsx
@@ -30,7 +30,7 @@ export const NetworkDetailSection = ({
   getNodeRef = () => undefined,
 }: NetworkDetailSectionProps) => {
   const colors = useThemeColors();
-  const [toastVisible, setToastVisible] = useState(false);
+  const [isLogged, setIsLogged] = useState(false);
 
   // 헤더 행 안의 key 또는 value가 활성 매치면 그 행에 스크롤 ref를 단다
   const rowRef = (name: string) =>
@@ -148,18 +148,18 @@ export const NetworkDetailSection = ({
               }}
               bindtap={() => {
                 console.log(`[lynx-console] ${section} body:`, body);
-                setToastVisible(true);
-                setTimeout(() => setToastVisible(false), 5000);
+                setIsLogged(true);
+                setTimeout(() => setIsLogged(false), 5000);
               }}
             >
               <text
                 className={"t3"}
                 style={{
-                  color: toastVisible ? colors.fg.accent : colors.fg.neutralSubtle,
+                  color: isLogged ? colors.fg.accent : colors.fg.neutralSubtle,
                   fontWeight: fontWeight.regular,
                 }}
               >
-                {toastVisible ? "✓ logged" : "log"}
+                {isLogged ? "✓ logged" : "log"}
               </text>
             </view>
           )}

--- a/package/src/components/NetworkDetailSection.tsx
+++ b/package/src/components/NetworkDetailSection.tsx
@@ -1,4 +1,4 @@
-import { type RefObject, useState } from "@lynx-js/react";
+import { type RefObject, useState, useRef } from "@lynx-js/react";
 import type { NodesRef } from "@lynx-js/types";
 import { matchNode } from "../hooks/useNetworkSearch";
 import { useThemeColors } from "../styles/ThemeContext";
@@ -30,6 +30,8 @@ export const NetworkDetailSection = ({
   getNodeRef = () => undefined,
 }: NetworkDetailSectionProps) => {
   const colors = useThemeColors();
+  const [toastVisible, setToastVisible] = useState(false);
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // 헤더 행 안의 key 또는 value가 활성 매치면 그 행에 스크롤 ref를 단다
   const rowRef = (name: string) =>
@@ -131,12 +133,39 @@ export const NetworkDetailSection = ({
         className={"np-detailSection"}
         ref={getNodeRef(matchNode.body(section))}
       >
-        <text
-          className={"np-detailSectionTitle t3"}
-          style={{ fontWeight: fontWeight.bold, color: colors.fg.neutral }}
-        >
-          Body
-        </text>
+        <view className={"np-detailSectionHeader"}>
+          <text
+            className={"np-detailSectionTitle t3"}
+            style={{ fontWeight: fontWeight.bold, color: colors.fg.neutral }}
+          >
+            Body
+          </text>
+          {body && (
+            <view
+              className={"np-logButton"}
+              style={{
+                backgroundColor: colors.bg.neutralWeak,
+                borderRadius: 4,
+              }}
+              bindtap={() => {
+                console.log(`[lynx-console] ${section} body:`, body);
+                if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+                setToastVisible(true);
+                toastTimerRef.current = setTimeout(() => setToastVisible(false), 5000);
+              }}
+            >
+              <text
+                className={"t3"}
+                style={{
+                  color: toastVisible ? colors.fg.accent : colors.fg.neutralSubtle,
+                  fontWeight: fontWeight.regular,
+                }}
+              >
+                {toastVisible ? "✓ logged" : "log"}
+              </text>
+            </view>
+          )}
+        </view>
         {error && (
           <text
             className={"np-errorText t3"}

--- a/package/src/components/NetworkDetailSection.tsx
+++ b/package/src/components/NetworkDetailSection.tsx
@@ -155,7 +155,9 @@ export const NetworkDetailSection = ({
               <text
                 className={"t3"}
                 style={{
-                  color: showLogConfirm ? colors.fg.accent : colors.fg.neutralSubtle,
+                  color: showLogConfirm
+                    ? colors.fg.accent
+                    : colors.fg.neutralSubtle,
                   fontWeight: fontWeight.regular,
                 }}
               >

--- a/package/src/components/NetworkPanel.css
+++ b/package/src/components/NetworkPanel.css
@@ -132,9 +132,6 @@
   margin-bottom: 12px;
 }
 
-.np-detailSectionTitle {
-}
-
 .np-detailSectionHeader {
   display: flex;
   flex-direction: row;
@@ -190,4 +187,3 @@
   padding: 2px 6px;
   border-radius: 4px;
 }
-

--- a/package/src/components/NetworkPanel.css
+++ b/package/src/components/NetworkPanel.css
@@ -133,13 +133,13 @@
 }
 
 .np-detailSectionTitle {
-  margin-bottom: 8px;
 }
 
 .np-detailSectionHeader {
   display: flex;
   flex-direction: row;
   align-items: center;
+  justify-content: space-between;
   gap: 4px;
   margin-bottom: 8px;
 }
@@ -185,3 +185,9 @@
   text-align: center;
   padding: 16px 0;
 }
+
+.np-logButton {
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+


### PR DESCRIPTION
Network 패널의 request/response Body 섹션에 log 버튼 추가해요.
탭하면 console.log 출력 + 버튼이 5초간 ✓ logged로 바뀌어요.
Lynx 클립보드 복사 불가 환경을 위한 기능이에요.

https://github.com/user-attachments/assets/b6665e21-5997-455f-bce4-63bca51b25c8

<img width="1182" height="782" alt="스크린샷 2026-06-23 오후 5 55 32" src="https://github.com/user-attachments/assets/e436e8b0-5035-4d1a-b93c-ab04c23706c3" />

