### PR TITLE
feat: 플로팅 버튼 롱프레스 없이 바로 드래그

### DIFF
--- a/.changeset/floating-button-instant-drag.md
+++ b/.changeset/floating-button-instant-drag.md
@@ -1,0 +1,5 @@
+---
+"lynx-console": patch
+---
+
+Make the floating button draggable instantly instead of requiring a long press. This matches vConsole's drag behavior and avoids triggering the native long-press action sheet. Dragging now starts as soon as the finger moves past the threshold; a plain tap still opens the console.

--- a/package/src/components/FloatingButton.tsx
+++ b/package/src/components/FloatingButton.tsx
@@ -1,8 +1,5 @@
 import type { ReactNode } from "@lynx-js/react";
-import {
-  type InitialPosition,
-  useLongPressDrag,
-} from "../hooks/useLongPressDrag";
+import { type InitialPosition, useDrag } from "../hooks/useDrag";
 import { useThemeColors } from "../styles/ThemeContext";
 import { duration } from "../styles/theme";
 import "./FloatingButton.css";
@@ -36,10 +33,9 @@ export const FloatingButton = ({
   initialPosition,
 }: FloatingButtonProps) => {
   const colors = useThemeColors();
-  const { phase, positionStyle, clearTimer, handlers } = useLongPressDrag(
-    bindtap,
-    { initialPosition },
-  );
+  const { phase, positionStyle, handlers } = useDrag(bindtap, {
+    initialPosition,
+  });
 
   const handleReload = () => {
     try {
@@ -73,7 +69,8 @@ export const FloatingButton = ({
       <view
         className={"fb-reloadButton"}
         style={{ backgroundColor: colors.palette.green600 }}
-        catchtouchstart={() => clearTimer()}
+        // reload 버튼 터치가 wrapper로 전파돼 드래그가 시작되지 않도록 막아요.
+        catchtouchstart={() => {}}
         bindtap={handleReload}
       >
         <text

--- a/package/src/components/FloatingButton.tsx
+++ b/package/src/components/FloatingButton.tsx
@@ -69,7 +69,6 @@ export const FloatingButton = ({
       <view
         className={"fb-reloadButton"}
         style={{ backgroundColor: colors.palette.green600 }}
-        // reload 버튼 터치가 wrapper로 전파돼 드래그가 시작되지 않도록 막아요.
         catchtouchstart={() => {}}
         bindtap={handleReload}
       >

--- a/package/src/hooks/useDrag.ts
+++ b/package/src/hooks/useDrag.ts
@@ -1,7 +1,6 @@
 import { useRef, useState } from "@lynx-js/react";
 import type { BaseTouchEvent, Target } from "@lynx-js/types";
 
-const LONG_PRESS_DURATION = 400;
 const MOVE_THRESHOLD = 5;
 
 const DEFAULT_RIGHT = 16;
@@ -51,14 +50,11 @@ interface SavedState {
 
 let saved: SavedState | null = null;
 
-interface UseLongPressDragOptions {
+interface UseDragOptions {
   initialPosition?: InitialPosition;
 }
 
-export function useLongPressDrag(
-  onTap: () => void,
-  options?: UseLongPressDragOptions,
-) {
+export function useDrag(onTap: () => void, options?: UseDragOptions) {
   const anchors = resolveAnchors(options?.initialPosition);
 
   // 저장된 위치는 anchor 조합이 동일할 때만 복원해요.
@@ -80,20 +76,12 @@ export function useLongPressDrag(
   const [tempX, setTempX] = useState(initX);
   const [tempY, setTempY] = useState(initY);
 
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const draggingRef = useRef(false);
   const startRef = useRef({ x: 0, y: 0, ax: 0, ay: 0 });
 
   // anchor 방향에 따라 드래그 부호 결정. right/bottom anchor면 드래그 방향과 값 변화가 반대.
   const xSign = anchors.horizontal === "right" ? -1 : 1;
   const ySign = anchors.vertical === "bottom" ? -1 : 1;
-
-  const clearTimer = () => {
-    if (timerRef.current) {
-      clearTimeout(timerRef.current);
-      timerRef.current = null;
-    }
-  };
 
   const handleTouchStart = (e: BaseTouchEvent<Target>) => {
     startRef.current = {
@@ -103,24 +91,21 @@ export function useLongPressDrag(
       ay: y,
     };
     draggingRef.current = false;
-
-    timerRef.current = setTimeout(() => {
-      draggingRef.current = true;
-      setPhase("dragging");
-      setTempX(x);
-      setTempY(y);
-    }, LONG_PRESS_DURATION);
   };
 
   const handleTouchMove = (e: BaseTouchEvent<Target>) => {
     const dx = e.detail.x - startRef.current.x;
     const dy = e.detail.y - startRef.current.y;
 
+    // 롱프레스 없이, 임계값을 넘어 움직이는 즉시 드래그를 시작해요.
     if (
       !draggingRef.current &&
       (Math.abs(dx) > MOVE_THRESHOLD || Math.abs(dy) > MOVE_THRESHOLD)
     ) {
-      clearTimer();
+      draggingRef.current = true;
+      setPhase("dragging");
+      setTempX(startRef.current.ax);
+      setTempY(startRef.current.ay);
     }
 
     if (!draggingRef.current) return;
@@ -130,8 +115,6 @@ export function useLongPressDrag(
   };
 
   const handleTouchEnd = () => {
-    clearTimer();
-
     if (draggingRef.current) {
       setX(tempX);
       setY(tempY);
@@ -161,7 +144,6 @@ export function useLongPressDrag(
   return {
     phase,
     positionStyle,
-    clearTimer,
     handlers: {
       catchtouchstart: handleTouchStart,
       catchtouchmove: handleTouchMove,

--- a/package/src/hooks/useDrag.ts
+++ b/package/src/hooks/useDrag.ts
@@ -97,7 +97,6 @@ export function useDrag(onTap: () => void, options?: UseDragOptions) {
     const dx = e.detail.x - startRef.current.x;
     const dy = e.detail.y - startRef.current.y;
 
-    // 롱프레스 없이, 임계값을 넘어 움직이는 즉시 드래그를 시작해요.
     if (
       !draggingRef.current &&
       (Math.abs(dx) > MOVE_THRESHOLD || Math.abs(dy) > MOVE_THRESHOLD)


### PR DESCRIPTION
## 배경

플로팅 버튼을 옮기려면 400ms 롱프레스가 필요했는데, 바로 드래그되도록 개선했어요.

## 변경 사항

- `useLongPressDrag` → `useDrag`로 이름 변경 (더 이상 롱프레스가 아니라서)
- 400ms 롱프레스 타이머 제거 → 손가락이 임계값(`MOVE_THRESHOLD` 5px)을 넘어 움직이는 즉시 드래그 시작

## 동작

- 짧은 탭 → 기존처럼 콘솔 열림
- 살짝 끌면 → 롱프레스 없이 바로 이동