### PR TITLE
feat: Lynx 엔진 3.9 지원

### DIFF
--- a/.changeset/support-lynx-engine-3-9.md
+++ b/.changeset/support-lynx-engine-3-9.md
@@ -1,0 +1,9 @@
+---
+"lynx-console": minor
+---
+
+Lynx 엔진 3.9까지 지원
+
+- `@lynx-js/types` 3.6~3.9 전 버전에서 타입체크 통과 확인, devDependency를 `^3.9.0`으로 업데이트
+- Lynx 3.7+에서 FCP 지표가 `pipeline`(`loadBundle`/`reloadBundle`) 엔트리에 실려오는 변경 대응 — deprecated된 `metric`(`fcp`) 엔트리와 새 방식 모두에서 FCP를 추출하도록 개선 (`useLatestFcp`, `PerformancePanel`)
+- 존재하지 않는 `colors.fg.accent` 토큰 참조로 typecheck가 실패하던 문제 수정 (`NetworkDetailSection`)

--- a/example/package.json
+++ b/example/package.json
@@ -19,7 +19,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "^0.4.6",
     "@lynx-js/react-rsbuild-plugin": "^0.13.0",
     "@lynx-js/rspeedy": "^0.13.3",
-    "@lynx-js/types": "^3.7.0",
+    "@lynx-js/types": "^3.9.0",
     "@rsbuild/plugin-type-check": "1.3.3",
     "@types/react": "^18.3.28",
     "typescript": "~5.9.3"

--- a/package/package.json
+++ b/package/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@lynx-js/react": "^0.117.0",
-    "@lynx-js/types": "^3.7.0",
+    "@lynx-js/types": "^3.9.0",
     "@types/react": "^18.3.28",
     "react": "^18.3.1",
     "tsdown": "^0.20.1",

--- a/package/src/components/NetworkDetailSection.tsx
+++ b/package/src/components/NetworkDetailSection.tsx
@@ -156,7 +156,7 @@ export const NetworkDetailSection = ({
                 className={"t3"}
                 style={{
                   color: showLogConfirm
-                    ? colors.fg.accent
+                    ? colors.palette.green600
                     : colors.fg.neutralSubtle,
                   fontWeight: fontWeight.regular,
                 }}

--- a/package/src/components/PerformancePanel.tsx
+++ b/package/src/components/PerformancePanel.tsx
@@ -3,41 +3,13 @@ import { stringify } from "javascript-stringify";
 import { useThemeColors } from "../styles/ThemeContext";
 import { fontWeight, type ThemeColors } from "../styles/theme";
 import type { PerformanceEntryData } from "../types";
+import { extractFcpMetrics } from "../utils/extractFcp";
 import "./PerformancePanel.css";
 
 interface PerformancePanelProps {
   performances: PerformanceEntryData[];
   clearPerformances: () => void;
 }
-
-interface FcpMetric {
-  name: string;
-  duration: number;
-}
-
-interface MetricFcpEntry {
-  totalFcp?: FcpMetric;
-  lynxFcp?: FcpMetric;
-  fcp?: FcpMetric;
-}
-
-const isMetricFcpEntry = (entry: PerformanceEntryData): boolean => {
-  return entry.entryType === "metric" && entry.name === "fcp";
-};
-
-const extractFcpMetrics = (entry: PerformanceEntryData) => {
-  if (!isMetricFcpEntry(entry) || !entry.rawEntry) {
-    return null;
-  }
-
-  const metricEntry = entry.rawEntry as MetricFcpEntry;
-
-  return {
-    totalFcp: metricEntry.totalFcp ?? undefined,
-    lynxFcp: metricEntry.lynxFcp ?? undefined,
-    fcp: metricEntry.fcp ?? undefined,
-  };
-};
 
 const formatDuration = (ms?: number): string => {
   if (ms === undefined) return "-";
@@ -179,8 +151,8 @@ export const PerformancePanel = ({
 
       <list scroll-orientation="vertical" className={"pp-list"}>
         {performances.map((perf) => {
-          const isMetricFcp = isMetricFcpEntry(perf);
           const fcpMetrics = extractFcpMetrics(perf);
+          const hasFcp = fcpMetrics !== null;
           const primaryFcp = getPrimaryFcpLabel(perf);
           const { totalFcp, lynxFcp, fcp } = fcpMetrics ?? {};
 
@@ -230,7 +202,7 @@ export const PerformancePanel = ({
                     setSelectedId(selectedId === perf.id ? null : perf.id)
                   }
                 >
-                  {isMetricFcp && primaryFcp && (
+                  {hasFcp && primaryFcp && (
                     <text
                       className={"pp-fcpHighlight t3"}
                       style={{
@@ -246,7 +218,7 @@ export const PerformancePanel = ({
 
                 {selectedId === perf.id && (
                   <view className={"pp-detailsContainer"}>
-                    {isMetricFcp && fcpMetrics && (
+                    {hasFcp && fcpMetrics && (
                       <view className={"pp-fcpSection"}>
                         {totalFcp !== undefined && (
                           <view

--- a/package/src/hooks/useLatestFcp.ts
+++ b/package/src/hooks/useLatestFcp.ts
@@ -1,22 +1,12 @@
 import { useEffect, useState } from "@lynx-js/react";
 import type { PerformanceEntryData } from "../types";
-
-interface FcpMetric {
-  name: string;
-  duration: number;
-}
-
-interface MetricFcpRawEntry {
-  totalFcp?: FcpMetric;
-  lynxFcp?: FcpMetric;
-  fcp?: FcpMetric;
-}
+import { extractFcpMetrics, type FcpMetric } from "../utils/extractFcp";
 
 const pickFcp = (entry: PerformanceEntryData): FcpMetric | undefined => {
-  if (entry.entryType !== "metric" || entry.name !== "fcp") return undefined;
-  const raw = entry.rawEntry as MetricFcpRawEntry | undefined;
-  if (raw?.totalFcp?.duration !== undefined) return raw.totalFcp;
-  if (raw?.lynxFcp?.duration !== undefined) return raw.lynxFcp;
+  const metrics = extractFcpMetrics(entry);
+  if (!metrics) return undefined;
+  if (metrics.totalFcp?.duration !== undefined) return metrics.totalFcp;
+  if (metrics.lynxFcp?.duration !== undefined) return metrics.lynxFcp;
   return undefined;
 };
 

--- a/package/src/setup/setupPerformanceMonitor.ts
+++ b/package/src/setup/setupPerformanceMonitor.ts
@@ -61,8 +61,8 @@ export const initPerformanceMonitor = () => {
   });
 
   observer.observe([
-    "pipeline", // LoadBundleEntry/ReloadBundleEntry — 엔진 3.7+에서는 FCP/init 타임스탬프도 여기에 실려온다
-    "init", // InitLynxviewEntry — 엔진 3.6까지만 디스패치됨
+    "pipeline", // LoadBundleEntry/ReloadBundleEntry — 엔진 3.7+에서는 FCP/init 타임스탬프도 여기에 실려옴
+    "init", // InitLynxviewEntry — 엔진 3.6까지만 사용
     "metric", // MetricFcpEntry(3.6까지) / MetricFspEntry
   ]);
 

--- a/package/src/setup/setupPerformanceMonitor.ts
+++ b/package/src/setup/setupPerformanceMonitor.ts
@@ -61,9 +61,9 @@ export const initPerformanceMonitor = () => {
   });
 
   observer.observe([
-    "pipeline", // LoadBundleEntry
-    "init", // InitLynxviewEntry
-    "metric", // MetricEntry
+    "pipeline", // LoadBundleEntry/ReloadBundleEntry — 엔진 3.7+에서는 FCP/init 타임스탬프도 여기에 실려온다
+    "init", // InitLynxviewEntry — 엔진 3.6까지만 디스패치됨
+    "metric", // MetricFcpEntry(3.6까지) / MetricFspEntry
   ]);
 
   console.log("[LynxConsole] ✅ Performance monitoring initialized");

--- a/package/src/utils/extractFcp.ts
+++ b/package/src/utils/extractFcp.ts
@@ -24,10 +24,12 @@ const isMetricFcpEntry = (entry: PerformanceEntryData): boolean => {
   return entry.entryType === "metric" && entry.name === "fcp";
 };
 
+// reload 엔트리의 name은 "reloadBundle"이 아니라
+// "reloadBundleFromNative" | "reloadBundleFromBts" (엔진 timing_constants.h 기준)
 const isBundlePipelineEntry = (entry: PerformanceEntryData): boolean => {
   return (
     entry.entryType === "pipeline" &&
-    (entry.name === "loadBundle" || entry.name === "reloadBundle")
+    (entry.name === "loadBundle" || entry.name.startsWith("reloadBundle"))
   );
 };
 

--- a/package/src/utils/extractFcp.ts
+++ b/package/src/utils/extractFcp.ts
@@ -1,0 +1,54 @@
+import type { PerformanceEntryData } from "../types";
+
+export interface FcpMetric {
+  name: string;
+  duration: number;
+}
+
+export interface FcpMetrics {
+  totalFcp?: FcpMetric;
+  lynxFcp?: FcpMetric;
+  fcp?: FcpMetric;
+}
+
+interface FcpRawEntry {
+  totalFcp?: FcpMetric;
+  lynxFcp?: FcpMetric;
+  fcp?: FcpMetric;
+}
+
+// Lynx 3.6까지는 FCP가 metric("fcp") 엔트리로만 전달되고,
+// 3.7부터는 pipeline("loadBundle"/"reloadBundle") 엔트리에 fcp 필드가 함께 실려온다
+// (MetricFcpEntry는 3.7부터 deprecated)
+const isMetricFcpEntry = (entry: PerformanceEntryData): boolean => {
+  return entry.entryType === "metric" && entry.name === "fcp";
+};
+
+const isBundlePipelineEntry = (entry: PerformanceEntryData): boolean => {
+  return (
+    entry.entryType === "pipeline" &&
+    (entry.name === "loadBundle" || entry.name === "reloadBundle")
+  );
+};
+
+export const extractFcpMetrics = (
+  entry: PerformanceEntryData,
+): FcpMetrics | null => {
+  if (!entry.rawEntry) return null;
+  if (!isMetricFcpEntry(entry) && !isBundlePipelineEntry(entry)) return null;
+
+  const raw = entry.rawEntry as FcpRawEntry;
+  const totalFcp = raw.totalFcp ?? undefined;
+  const lynxFcp = raw.lynxFcp ?? undefined;
+  const fcp = raw.fcp ?? undefined;
+
+  if (
+    totalFcp?.duration === undefined &&
+    lynxFcp?.duration === undefined &&
+    fcp?.duration === undefined
+  ) {
+    return null;
+  }
+
+  return { totalFcp, lynxFcp, fcp };
+};

--- a/package/src/utils/extractFcp.ts
+++ b/package/src/utils/extractFcp.ts
@@ -24,8 +24,6 @@ const isMetricFcpEntry = (entry: PerformanceEntryData): boolean => {
   return entry.entryType === "metric" && entry.name === "fcp";
 };
 
-// reload 엔트리의 name은 "reloadBundle"이 아니라
-// "reloadBundleFromNative" | "reloadBundleFromBts" (엔진 timing_constants.h 기준)
 const isBundlePipelineEntry = (entry: PerformanceEntryData): boolean => {
   return (
     entry.entryType === "pipeline" &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,12 +1028,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lynx-js/types@npm:^3.7.0":
-  version: 3.7.0
-  resolution: "@lynx-js/types@npm:3.7.0"
+"@lynx-js/types@npm:^3.9.0":
+  version: 3.9.0
+  resolution: "@lynx-js/types@npm:3.9.0"
   dependencies:
     csstype: "npm:3.1.3"
-  checksum: 10c0/877890c5d6f6b0b719dc3aa6f264997b26bab5ce6b6da9a2f05683ea4a9567a767255be5f243d0587a1514596724c6a37eb36b5b37704f5e409652fb357d4ebc
+  checksum: 10c0/a9543e32d3b646633db27d1765e3ae7e1d4c7f42e30ac6f32483ebf7ea12340d64c3620635a1863f3c81a493a673f90a4e498698129976d6fefcf9e1d25639d7
   languageName: node
   linkType: hard
 
@@ -4350,7 +4350,7 @@ __metadata:
     "@lynx-js/react": "npm:^0.117.0"
     "@lynx-js/react-rsbuild-plugin": "npm:^0.13.0"
     "@lynx-js/rspeedy": "npm:^0.13.3"
-    "@lynx-js/types": "npm:^3.7.0"
+    "@lynx-js/types": "npm:^3.9.0"
     "@rsbuild/plugin-type-check": "npm:1.3.3"
     "@types/react": "npm:^18.3.28"
     lynx-console: "workspace:*"
@@ -4363,7 +4363,7 @@ __metadata:
   resolution: "lynx-console@workspace:package"
   dependencies:
     "@lynx-js/react": "npm:^0.117.0"
-    "@lynx-js/types": "npm:^3.7.0"
+    "@lynx-js/types": "npm:^3.9.0"
     "@types/react": "npm:^18.3.28"
     devalue: "npm:^5.6.4"
     javascript-stringify: "npm:^2.1.0"


### PR DESCRIPTION
## 요약

Lynx 엔진 3.6~3.9 차이를 분석하고 3.9까지 동작하도록 대응해요.

## 배경 — 엔진 3.7의 performance 엔트리 변경

- 3.7부터 `init` 계열 엔트리와 standalone `metric`/`fcp` 엔트리(MetricFcpEntry)가 **더 이상 사용되지 않아요**
- FCP·init 타임스탬프는 `pipeline`(`loadBundle`/`reloadBundleFrom*`) 엔트리로 병합됐어요
- 기존 코드는 `metric`/`fcp` 엔트리에서만 FCP를 읽어서 3.7+ 엔진에서는 FCP가 표시되지 않았어요

3.8/3.9는 추가만 있고 breaking은 없어요.

## 변경 사항

- FCP 추출을 `extractFcp.ts` 공용 유틸로 분리하고, `metric`/`fcp`(≤3.6)와 `pipeline` 번들 엔트리(3.7+) 양쪽에서 추출 (`useLatestFcp`, `PerformancePanel` 공유)
- reload 엔트리 name 매칭 수정 — 엔진은 `reloadBundle`이 아니라 `reloadBundleFromNative`/`reloadBundleFromBts`를 넣어요
- `@lynx-js/types` devDependency `^3.9.0`으로 업데이트 (peerDependency는 `^3.6.0` 유지 — 3.6~3.9 사용자 모두 커버)
- 존재하지 않는 `colors.fg.accent` 토큰 참조로 깨져 있던 typecheck 수정


🤖 Generated with [Claude Code](https://claude.com/claude-code)
