### PR TITLE
fix: +json 접미사 Content-Type 응답 본문 파싱

### DIFF
--- a/.changeset/soft-onions-repeat.md
+++ b/.changeset/soft-onions-repeat.md
@@ -1,0 +1,5 @@
+---
+"lynx-console": patch
+---
+
+fix: `+json` 접미사 Content-Type(application/graphql-response+json 등) 응답 본문이 Network 탭에 표시되지 않던 문제 수정

--- a/example/src/App.css
+++ b/example/src/App.css
@@ -58,6 +58,9 @@
 .app-deleteButton {
   background-color: #fff5f5;
 }
+.app-graphqlButton {
+  background-color: #fdf2f8;
+}
 
 .app-consoleButtonText {
   color: #4a5568;
@@ -73,4 +76,7 @@
 }
 .app-deleteButtonText {
   color: #e53e3e;
+}
+.app-graphqlButtonText {
+  color: #db2777;
 }

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -107,6 +107,36 @@ const App = () => {
       console.error('DELETE Error:', error);
     }
   };
+  // 응답 Content-Type이 application/graphql-response+json 인 케이스
+  // graphql.org 공식 사이트의 예제 엔드포인트 (SWAPI 스키마)
+  // 끝의 슬래시가 없으면 308 리다이렉트되므로 그대로 둬요
+  const testGraphqlRequest = async () => {
+    try {
+      const response = await fetch('https://graphql.org/graphql/?op=GetFilm', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/graphql-response+json',
+        },
+        body: JSON.stringify({
+          query: `query GetFilm($filmID: ID!) {
+            film(filmID: $filmID) {
+              title
+              episodeID
+              director
+              releaseDate
+            }
+          }`,
+          variables: { filmID: '1' },
+        }),
+      });
+      const data = await response.json();
+      console.log('GraphQL Response:', data);
+    } catch (error) {
+      console.error('GraphQL Error:', error);
+    }
+  };
+
   return (
     <view className="app-container">
       <list className="app-list" scroll-orientation="vertical">
@@ -193,6 +223,14 @@ const App = () => {
             >
               <text className="app-buttonText app-deleteButtonText">
                 DELETE Request
+              </text>
+            </view>
+            <view
+              bindtap={testGraphqlRequest}
+              className="app-baseButton app-graphqlButton"
+            >
+              <text className="app-buttonText app-graphqlButtonText">
+                GraphQL Request
               </text>
             </view>
           </view>

--- a/package/src/setup/setupNetworkMonitor.ts
+++ b/package/src/setup/setupNetworkMonitor.ts
@@ -201,10 +201,11 @@ export const initNetworkMonitor = () => {
         });
 
         const contentType = headerMap["content-type"];
-        if (contentType?.includes("application/json")) {
+        const mimeType = contentType?.split(";")[0]?.trim().toLowerCase();
+        if (mimeType === "application/json" || mimeType?.endsWith("+json")) {
           const json = await clonedResponse.json();
           responseBody = stringify(json, null, 2, { references: true }) ?? "";
-        } else if (contentType?.includes("text")) {
+        } else if (mimeType?.includes("text")) {
           responseBody = await clonedResponse.text();
         }
       } catch (error) {


### PR DESCRIPTION
Network 탭에서 GraphQL 응답 본문이 표시되지 않던 문제를 수정해요.

응답 본문 파싱이 Content-Type을 includes("application/json")으로만 판정해서, GraphQL 표준 응답 타입인 application/graphql-response+json이 걸리지 않았어요. 뒤따르는 includes("text") 분기에도 해당하지 않아
responseBody가 빈 문자열로 남았어요.

RFC 6839 구조화 접미사 기준으로 +json으로 끝나는 MIME 타입도 JSON으로
처리해요. application/problem+json 같은 타입도 함께 해결돼요.

- ";" 앞만 잘라내 charset=utf-8 같은 파라미터를 제거
- 헤더 값 소문자 정규화 (헤더 키 정규화는 기존과 동일)
- example에 GraphQL 호출 예제 추가