### PR TITLE
fix: example의 source.include를 경로 독립적으로 수정

### DIFF
--- a/example/lynx.config.ts
+++ b/example/lynx.config.ts
@@ -9,6 +9,8 @@ import { pluginTypeCheck } from '@rsbuild/plugin-type-check';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+const packageDir = path.resolve(__dirname, '../package');
+
 const getLocalIP = () => {
   const interfaces = os.networkInterfaces();
   for (const interfaceName in interfaces) {
@@ -40,7 +42,11 @@ export default defineConfig({
       main: './src/index.tsx',
     },
     define: { console: 'globalThis.console' },
-    include: [/@lynx-js\/preact-devtools/, /lynx-console/],
+    include: [
+      /@lynx-js\/preact-devtools/,
+      { and: [packageDir, { not: /[\\/]node_modules[\\/]/ }] },
+      /[\\/]node_modules[\\/]devalue[\\/]/,
+    ],
   },
   output: {
     assetPrefix: process.env.ASSET_PREFIX ?? `http://${getLocalIP()}:<port>/`,


### PR DESCRIPTION
## 문제

Lynx Explorer에서 배포된 데모를 열면 앱이 아예 뜨지 않아요.

```
loadCard failed SyntaxError: expecting ')'
    at file://view3/.rspeedy/main/background....
```

해당 위치의 코드는 `(r??=new Set).has(t)` 예요. `??=`(ES2021)를 PrimJS가 파싱하지 못해서
`(` → `r` 까지 읽고 `)`를 기대하다 터져요. 출처는 `devalue` 예요.

```
node_modules/devalue/src/parse.js:82:  hydrating ??= new Set();
```

## 원인

`source.include`의 `/lynx-console/` 정규식이 **파일 절대경로**에 매칭돼요.
**클론한 디렉터리 이름이 `lynx-console`이라서 레포 안 모든 파일이 우연히 매칭되고 있었고, vercel과 cloudflare에서는 매칭되지 않았어요.**
devalue를 이름으로 포함시킨 게 아니었어요.

## 수정

```diff
-    include: [/@lynx-js\/preact-devtools/, /lynx-console/],
+    include: [
+      /@lynx-js\/preact-devtools/,
+      /[\\/]node_modules[\\/]devalue[\\/]/,
+    ],
```

devalue를 패키지 디렉터리 경로로 앵커했어요. `[\\/]`는 POSIX/Windows 구분자를 모두 받아요.
클론 위치와 무관하게 매칭돼요.

## 검증

```js
// before: (r??=new Set).has(t)
// after:  null!=r||(r=new Set),r.has(t)
```