### PR TITLE
fix: 메인 페이지 데모 iframe 크기를 화면에 맞춰 키움

### DIFF
--- a/docs/components/HomeHero.module.css
+++ b/docs/components/HomeHero.module.css
@@ -116,8 +116,9 @@
 }
 
 .phone {
-  width: 306px;
-  height: 616px;
+  box-sizing: border-box;
+  width: min(360px, 86vw);
+  aspect-ratio: 306 / 616;
   padding: 8px;
   border: 1px solid var(--lc-border);
   border-radius: 38px;
@@ -166,5 +167,11 @@
   .actions,
   .explorerRow {
     justify-content: flex-start;
+  }
+
+  /* 화면 높이가 허락하는 만큼 데모를 키워요. 최소치는 예전 크기보다 조금 커요. */
+  .phone {
+    width: auto;
+    height: clamp(660px, calc(100vh - 160px), 860px);
   }
 }


### PR DESCRIPTION
## 무엇을

문서 홈 히어로에 임베드된 라이브 데모가 너무 작아서, 고정 `306x616` 대신 화면 크기를 따라가게 바꿨어요.

## 어떻게

`docs/components/HomeHero.module.css` 의 `.phone` 만 고쳤어요.

- 데스크톱(≥960px): 높이 `clamp(660px, calc(100vh - 160px), 860px)`, 너비는 `aspect-ratio: 306 / 616` 로 따라와요
- 모바일: `min(360px, 86vw)` 로 화면 폭을 거의 채워요
- 최소치를 `660px` 로 잡아서 화면이 낮아도 예전(616px)보다 작아지지 않아요

| 뷰포트 | 이전 | 이후 |
| --- | --- | --- |
| 1400×900 | 306×616 | 368×740 |
| 1512×1150 | 306×616 | 427×860 |
| 375×812 (모바일) | 306×616 | 322×649 |

더 키우고 싶으면 `clamp()` 의 최대값 `860px` 만 올리면 돼요.

## 확인

- `yarn build && yarn build:example && yarn workspace lynx-console-test build:web` 후 `yarn dev:docs` 로 띄워서 데스크톱 · 모바일 둘 다 확인했어요
- `yarn check` 통과
- `package/**` 변경 없어서 changeset 은 필요 없어요

🤖 Generated with [Claude Code](https://claude.com/claude-code)