### PR TITLE
feat: 설치 명령에 패키지 매니저 탭 추가

### DIFF
--- a/docs/components/QuickStart.tsx
+++ b/docs/components/QuickStart.tsx
@@ -1,7 +1,7 @@
 import { useLang } from "rspress/runtime";
 import styles from "./QuickStart.module.css";
 
-const INSTALL = "yarn add lynx-console";
+const INSTALL = "npm install lynx-console";
 
 const INIT = `// src/index.tsx
 import {

--- a/docs/src/en/guide/getting-started.mdx
+++ b/docs/src/en/guide/getting-started.mdx
@@ -3,20 +3,31 @@ title: Getting Started
 description: Install, configure the build, initialize the monitors, render the console.
 ---
 
+import { PackageManagerTabs } from '@theme';
+
 # Getting Started
 
 ## Installation
 
-```bash
-yarn add lynx-console
-```
+<PackageManagerTabs
+  command={{
+    npm: 'npm install lynx-console',
+    yarn: 'yarn add lynx-console',
+    pnpm: 'pnpm add lynx-console',
+    bun: 'bun add lynx-console',
+  }}
+/>
 
 ### Peer dependencies
 
-```bash
-yarn add @lynx-js/react @lynx-js/types
-yarn add -D @types/react
-```
+<PackageManagerTabs
+  command={{
+    npm: 'npm install @lynx-js/react @lynx-js/types\nnpm install -D @types/react',
+    yarn: 'yarn add @lynx-js/react @lynx-js/types\nyarn add -D @types/react',
+    pnpm: 'pnpm add @lynx-js/react @lynx-js/types\npnpm add -D @types/react',
+    bun: 'bun add @lynx-js/react @lynx-js/types\nbun add -D @types/react',
+  }}
+/>
 
 ## 0. Configure your build (required)
 

--- a/docs/src/ko/guide/getting-started.mdx
+++ b/docs/src/ko/guide/getting-started.mdx
@@ -3,20 +3,31 @@ title: 시작하기
 description: 설치, 빌드 설정, 모니터 초기화, 콘솔 렌더까지의 과정이에요.
 ---
 
+import { PackageManagerTabs } from '@theme';
+
 # 시작하기
 
 ## 설치
 
-```bash
-yarn add lynx-console
-```
+<PackageManagerTabs
+  command={{
+    npm: 'npm install lynx-console',
+    yarn: 'yarn add lynx-console',
+    pnpm: 'pnpm add lynx-console',
+    bun: 'bun add lynx-console',
+  }}
+/>
 
 ### Peer dependencies
 
-```bash
-yarn add @lynx-js/react @lynx-js/types
-yarn add -D @types/react
-```
+<PackageManagerTabs
+  command={{
+    npm: 'npm install @lynx-js/react @lynx-js/types\nnpm install -D @types/react',
+    yarn: 'yarn add @lynx-js/react @lynx-js/types\nyarn add -D @types/react',
+    pnpm: 'pnpm add @lynx-js/react @lynx-js/types\npnpm add -D @types/react',
+    bun: 'bun add @lynx-js/react @lynx-js/types\nbun add -D @types/react',
+  }}
+/>
 
 ## 0. 빌드 설정 (필수)
 


### PR DESCRIPTION
## 무엇을

시작하기 문서의 설치 · peer dependencies 블록을 Rspress 내장 `PackageManagerTabs` 로 바꿔 **npm / yarn / pnpm / bun** 을 골라 볼 수 있게 했어요. 홈 QuickStart 의 설치 명령도 yarn 에서 npm 으로 바꿨고요.

선택은 `groupId: "package.manager"` 로 페이지 안의 모든 블록이 함께 바뀌고, 다른 문서나 언어로 넘어가도 유지돼요.

## 왜 이렇게

- `.md` 에서는 JSX 가 렌더되지 않고 사라져서 `getting-started` 를 `.mdx` 로 옮겼어요. 라우트(`/guide/getting-started`)는 그대로라 nav · sidebar 링크는 손댈 게 없어요.
- `command` 를 문자열 대신 매니저별 객체로 줬어요. 문자열이면 pnpm 이 `pnpm install lynx-console` 로 나오는데, pnpm 은 `add` 를 써야 해요.
- `demo.mdx` 의 `yarn install` · `yarn dev:example` 은 이 레포를 클론해서 돌리는 명령이라 그대로 뒀어요.

## 확인한 것

- `rspress build` 통과, en · ko 두 페이지 모두 탭 렌더 확인
- 개발 서버에서 pnpm 탭을 눌러 두 블록이 함께 바뀌고 페이지 이동 후에도 유지되는 것 확인
- `yarn check` 통과


🤖 Generated with [Claude Code](https://claude.com/claude-code)