### PR TITLE
feat: README 와 문서 사이트에 중국어 추가

### DIFF
--- a/.changeset/tidy-crabs-shave.md
+++ b/.changeset/tidy-crabs-shave.md
@@ -1,0 +1,5 @@
+---
+"lynx-console": patch
+---
+
+README 중국어(간체) 번역을 추가하고, 세 README 의 언어 전환 줄을 맞췄어요

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,11 +31,14 @@ yarn format         # biome 자동 수정
 
 ## 문서 사이트 규칙
 
-- 콘텐츠는 `docs/src/en` 과 `docs/src/ko` 에 **양쪽 다** 둬요. 한쪽만 고치지 않아요.
+- 콘텐츠는 `docs/src/en` · `docs/src/ko` · `docs/src/zh` 에 **세 벌 다** 둬요. 한쪽만 고치지 않아요.
+  중국어는 간체(简体中文)로 써요.
 - 한국어 문서는 해요체로 써요. 영어를 그대로 옮긴 듯한 문장이나, 코드 스팬 뒤 조사 앞
   띄어쓰기(`` `foo` 는 ``)를 만들지 않아요.
 - 기본 언어(en)는 라우트에서 `/en` 접두사가 빠져요. 영문 문서의 내부 링크는 `/guide/...`,
-  한국어는 `/ko/guide/...` 로 써요.
+  한국어는 `/ko/guide/...`, 중국어는 `/zh/guide/...` 로 써요.
+- 로케일 목록은 `docs/siteMeta.mjs` 의 `LOCALES` 한 곳에 있어요. 언어를 추가하면 여기와
+  `docs/rspress.config.ts`, 홈 컴포넌트의 `TEXT` 사전, `head-meta.mjs` 의 `DEFAULTS` 를 같이 채워요.
 - `.md` 에서는 raw HTML/JSX 가 렌더되지 않고 사라져요. `<a>`, `<img>`, style 객체가 필요하면
   파일 확장자를 `.mdx` 로 바꿔요.
 - `docs/src/public/` 은 전부 생성물이에요. `docs/scripts/sync-demo.mjs` 가 예제 빌드
@@ -67,6 +70,8 @@ yarn format         # biome 자동 수정
   쓰지 않아요. 클론 디렉터리 이름에 우연히 매칭돼 로컬만 통과하고 CI 에서 깨져요.
   `path.resolve(__dirname, ...)` 나 `[\\/]node_modules[\\/]<pkg>[\\/]` 형태로 써요.
 - `package/**` 를 고치면 changeset 이 필요해요 (CI 가 검사해요). `yarn changeset` 으로 만들어요.
+- README 는 `package/README.md`(en) · `README_ko.md` · `README_zh.md` 세 벌이에요. 루트의 같은 이름
+  파일은 심링크예요. 하나를 고치면 나머지도 맞춰요.
 - 커밋 메시지는 한국어로 써요.
 
 ## 참고 문서

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,0 +1,1 @@
+package/README_zh.md

--- a/docs/components/HomeHero.tsx
+++ b/docs/components/HomeHero.tsx
@@ -25,12 +25,13 @@ const TEXT = {
     openInTab: "Open the demo in a new tab",
   },
   ko: { explorer: "Lynx Explorer로 열기", openInTab: "새 탭에서 데모 열기" },
+  zh: { explorer: "用 Lynx Explorer 打开", openInTab: "在新标签页打开演示" },
 } as const;
 
 export function HomeHero() {
   const { page } = usePageData();
   const lang = useLang();
-  const t = TEXT[lang === "ko" ? "ko" : "en"];
+  const t = TEXT[lang in TEXT ? (lang as keyof typeof TEXT) : "en"];
   const hero = (page.frontmatter?.hero ?? {}) as Hero;
 
   return (

--- a/docs/components/QuickStart.tsx
+++ b/docs/components/QuickStart.tsx
@@ -33,11 +33,17 @@ const TEXT = {
     moreLink: "/ko/guide/getting-started",
     steps: ["설치", "진입점에서 초기화", "컴포넌트 렌더"],
   },
+  zh: {
+    title: "三步就能跑起来",
+    more: "完整指南 →",
+    moreLink: "/zh/guide/getting-started",
+    steps: ["安装", "在入口初始化", "渲染组件"],
+  },
 } as const;
 
 export function QuickStart() {
   const lang = useLang();
-  const t = TEXT[lang === "ko" ? "ko" : "en"];
+  const t = TEXT[lang in TEXT ? (lang as keyof typeof TEXT) : "en"];
   const snippets = [INSTALL, INIT, RENDER];
 
   return (

--- a/docs/rspress.config.ts
+++ b/docs/rspress.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
       lang: "zh",
       label: "简体中文",
       title: "lynx-console",
-      description: "可以嵌入 Lynx 应用的应用内开发者控制台",
+      description: "可以嵌入 Lynx 应用的开发者控制台",
     },
   ],
   globalStyles: path.resolve("styles/global.css"),

--- a/docs/rspress.config.ts
+++ b/docs/rspress.config.ts
@@ -25,6 +25,12 @@ export default defineConfig({
       title: "lynx-console",
       description: "Lynx 앱에 내장할 수 있는 인앱 개발자 콘솔",
     },
+    {
+      lang: "zh",
+      label: "简体中文",
+      title: "lynx-console",
+      description: "可以嵌入 Lynx 应用的应用内开发者控制台",
+    },
   ],
   globalStyles: path.resolve("styles/global.css"),
   route: {
@@ -103,6 +109,41 @@ export default defineConfig({
             {
               text: "API",
               items: [{ text: "API 레퍼런스", link: "/ko/api/" }],
+            },
+          ],
+        },
+      },
+      {
+        lang: "zh",
+        label: "简体中文",
+        outlineTitle: "目录",
+        prevPageText: "上一页",
+        nextPageText: "下一页",
+        editLink: {
+          docRepoBaseUrl: `${GITHUB_URL}/tree/main/docs/src`,
+          text: "在 GitHub 上编辑此页",
+        },
+        nav: [
+          { text: "指南", link: "/zh/guide/getting-started" },
+          { text: "API", link: "/zh/api/" },
+          { text: "演示", link: "/zh/guide/demo" },
+        ],
+        sidebar: {
+          "/zh/guide/": [
+            {
+              text: "指南",
+              items: [
+                { text: "介绍", link: "/zh/guide/introduction" },
+                { text: "快速开始", link: "/zh/guide/getting-started" },
+                { text: "自定义标签页与 ref", link: "/zh/guide/customizing" },
+                { text: "体验演示", link: "/zh/guide/demo" },
+              ],
+            },
+          ],
+          "/zh/api/": [
+            {
+              text: "API",
+              items: [{ text: "API 参考", link: "/zh/api/" }],
             },
           ],
         },

--- a/docs/scripts/head-meta.mjs
+++ b/docs/scripts/head-meta.mjs
@@ -1,5 +1,11 @@
 import fs from "node:fs";
-import { SITE_URL } from "../siteMeta.mjs";
+import {
+  alternatePaths,
+  DEFAULT_LOCALE,
+  LOCALES,
+  SITE_URL,
+  stripLocale,
+} from "../siteMeta.mjs";
 
 const SITE_NAME = "lynx-console";
 const OG_IMAGE = `${SITE_URL}/og.png`;
@@ -9,11 +15,19 @@ const DEFAULTS = {
     title: "lynx-console",
     description:
       "An in-app developer console for Lynx apps. Read console logs, fetch requests, and performance metrics on a real device, with no debugger attached.",
+    ogLocale: "en_US",
   },
   ko: {
     title: "lynx-console",
     description:
       "Lynx 앱에 넣는 인앱 개발자 콘솔이에요. 디버거 없이도 실기기에서 콘솔 로그, fetch 요청, 성능 지표를 봐요.",
+    ogLocale: "ko_KR",
+  },
+  zh: {
+    title: "lynx-console",
+    description:
+      "Lynx 应用的应用内开发者控制台。不用连调试器，就能在真机上查看控制台日志、fetch 请求和性能指标。",
+    ogLocale: "zh_CN",
   },
 };
 
@@ -37,18 +51,9 @@ function readFrontmatter(absolutePath) {
   }
 }
 
-// `/ko/guide/demo` <-> `/guide/demo`. 기본 언어(en)는 접두사가 없어요.
 function toPath(routePath) {
   const clean = routePath.replace(/index$/, "").replace(/\/+$/, "/");
   return clean.startsWith("/") ? clean : `/${clean}`;
-}
-
-function alternates(routePath) {
-  const p = toPath(routePath);
-  const isKo = p === "/ko" || p.startsWith("/ko/");
-  const en = isKo ? p.replace(/^\/ko/, "") || "/" : p;
-  const ko = isKo ? p : `/ko${p === "/" ? "/" : p}`;
-  return { en, ko };
 }
 
 function escapeAttr(value) {
@@ -59,27 +64,29 @@ function escapeAttr(value) {
 }
 
 export function buildHead(route) {
-  const lang = route.lang === "ko" ? "ko" : "en";
+  const lang = LOCALES.includes(route.lang) ? route.lang : DEFAULT_LOCALE;
   const fm = readFrontmatter(route.absolutePath);
   const fallback = DEFAULTS[lang];
-  const isHome =
-    toPath(route.routePath) === "/" || toPath(route.routePath) === "/ko/";
+  const routePath = toPath(route.routePath);
+  const isHome = stripLocale(routePath) === "/";
   const title = isHome
     ? [SITE_NAME, fm.titleSuffix].filter(Boolean).join(" - ")
     : `${fm.title ?? fallback.title} - ${SITE_NAME}`;
   const description = fm.description ?? fallback.description;
 
-  const canonical = `${SITE_URL}${toPath(route.routePath)}`;
-  const { en, ko } = alternates(route.routePath);
+  const canonical = `${SITE_URL}${routePath}`;
+  const alternates = alternatePaths(routePath);
 
   const tags = [
     `<link rel="canonical" href="${escapeAttr(canonical)}">`,
-    `<link rel="alternate" hreflang="en" href="${escapeAttr(`${SITE_URL}${en}`)}">`,
-    `<link rel="alternate" hreflang="ko" href="${escapeAttr(`${SITE_URL}${ko}`)}">`,
-    `<link rel="alternate" hreflang="x-default" href="${escapeAttr(`${SITE_URL}${en}`)}">`,
+    ...LOCALES.map(
+      (l) =>
+        `<link rel="alternate" hreflang="${l}" href="${escapeAttr(`${SITE_URL}${alternates[l]}`)}">`,
+    ),
+    `<link rel="alternate" hreflang="x-default" href="${escapeAttr(`${SITE_URL}${alternates[DEFAULT_LOCALE]}`)}">`,
     `<meta property="og:type" content="website">`,
     `<meta property="og:site_name" content="${SITE_NAME}">`,
-    `<meta property="og:locale" content="${lang === "ko" ? "ko_KR" : "en_US"}">`,
+    `<meta property="og:locale" content="${fallback.ogLocale}">`,
     `<meta property="og:url" content="${escapeAttr(canonical)}">`,
     `<meta property="og:title" content="${escapeAttr(title)}">`,
     `<meta property="og:description" content="${escapeAttr(description)}">`,
@@ -94,7 +101,7 @@ export function buildHead(route) {
       "@type": "SoftwareSourceCode",
       name: SITE_NAME,
       description,
-      url: `${SITE_URL}${toPath(route.routePath)}`,
+      url: `${SITE_URL}${routePath}`,
       codeRepository: "https://github.com/daangn/lynx-console",
       programmingLanguage: "TypeScript",
       runtimePlatform: "Lynx",

--- a/docs/scripts/head-meta.mjs
+++ b/docs/scripts/head-meta.mjs
@@ -26,7 +26,7 @@ const DEFAULTS = {
   zh: {
     title: "lynx-console",
     description:
-      "Lynx 应用的应用内开发者控制台。不用连调试器，就能在真机上查看控制台日志、fetch 请求和性能指标。",
+      "可以嵌入 Lynx 应用的开发者控制台。不用连调试器，就能在真机上查看控制台日志、fetch 请求和性能指标。",
     ogLocale: "zh_CN",
   },
 };

--- a/docs/scripts/postbuild.mjs
+++ b/docs/scripts/postbuild.mjs
@@ -2,7 +2,12 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { SITE_URL } from "../siteMeta.mjs";
+import {
+  alternatePaths,
+  DEFAULT_LOCALE,
+  LOCALES,
+  SITE_URL,
+} from "../siteMeta.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const outDir = path.resolve(__dirname, "..", "doc_build");
@@ -30,26 +35,21 @@ function collectHtml(dir, base = "") {
   return routes;
 }
 
-function alternates(route) {
-  const isKo = route === "/ko/" || route.startsWith("/ko/");
-  const en = isKo ? route.replace(/^\/ko/, "") || "/" : route;
-  const ko = isKo ? route : `/ko${route}`;
-  return { en, ko };
-}
-
 const routes = collectHtml(outDir).sort();
 const today = new Date().toISOString().slice(0, 10);
 
 const urls = routes
   .map((route) => {
-    const { en, ko } = alternates(route);
+    const alternates = alternatePaths(route);
     return [
       "  <url>",
       `    <loc>${SITE_URL}${route}</loc>`,
       `    <lastmod>${today}</lastmod>`,
-      `    <xhtml:link rel="alternate" hreflang="en" href="${SITE_URL}${en}"/>`,
-      `    <xhtml:link rel="alternate" hreflang="ko" href="${SITE_URL}${ko}"/>`,
-      `    <xhtml:link rel="alternate" hreflang="x-default" href="${SITE_URL}${en}"/>`,
+      ...LOCALES.map(
+        (lang) =>
+          `    <xhtml:link rel="alternate" hreflang="${lang}" href="${SITE_URL}${alternates[lang]}"/>`,
+      ),
+      `    <xhtml:link rel="alternate" hreflang="x-default" href="${SITE_URL}${alternates[DEFAULT_LOCALE]}"/>`,
       "  </url>",
     ].join("\n");
   })

--- a/docs/siteMeta.mjs
+++ b/docs/siteMeta.mjs
@@ -8,3 +8,28 @@ export function demoBundleUrl(siteUrl = SITE_URL) {
 export function lynxExplorerUrl(siteUrl = SITE_URL) {
   return `lynx://open?url=${encodeURIComponent(demoBundleUrl(siteUrl))}`;
 }
+
+export const DEFAULT_LOCALE = "en";
+export const LOCALES = ["en", "ko", "zh"];
+
+// 기본 언어(en)는 라우트에서 접두사가 빠져요. `/zh/guide/demo` <-> `/guide/demo`.
+export function stripLocale(routePath) {
+  for (const lang of LOCALES) {
+    if (lang === DEFAULT_LOCALE) continue;
+    if (routePath === `/${lang}` || routePath === `/${lang}/`) return "/";
+    if (routePath.startsWith(`/${lang}/`))
+      return routePath.slice(`/${lang}`.length);
+  }
+  return routePath;
+}
+
+// 라우트 하나를 모든 언어의 경로로 펼쳐요. hreflang 과 sitemap 이 같이 써요.
+export function alternatePaths(routePath) {
+  const base = stripLocale(routePath);
+  return Object.fromEntries(
+    LOCALES.map((lang) => [
+      lang,
+      lang === DEFAULT_LOCALE ? base : `/${lang}${base}`,
+    ]),
+  );
+}

--- a/docs/src/zh/api/index.md
+++ b/docs/src/zh/api/index.md
@@ -1,0 +1,46 @@
+---
+title: API 参考
+description: props、console handle 和监视器初始化函数。
+---
+
+# API 参考
+
+## `LynxConsole` props
+
+| Prop | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `theme` | `"light" \| "dark"` | `"light"` | 控制台 UI 主题。 |
+| `safeAreaInsetBottom` | `string` | `"50px"` | 面板底部的安全区域内边距。 |
+| `customTabs` | `CustomTab[]` | `undefined` | 要在控制台里额外显示的标签页。 |
+| `initialPosition` | `{ top?: number; left?: number; right?: number; bottom?: number }` | `{ right: 16, bottom: 84 }` | 悬浮按钮的初始位置（px）。四个方向互相独立，所以可以吸附到任意一个角（例如 `{ top: 50, left: 16 }`）。同时给了 `top` 和 `bottom`（或 `left` 和 `right`）时，`top` / `left` 生效。用户拖动过按钮之后，保存下来的位置优先。 |
+
+## `CustomTab`
+
+| 属性 | 类型 | 说明 |
+| --- | --- | --- |
+| `key` | `string` | 标签页的唯一标识。 |
+| `label` | `string` | 标签页的文字。 |
+| `renderContent` | `() => ReactNode` | 渲染标签页内容。 |
+
+## `LynxConsoleHandle`
+
+通过 `LynxConsole` 上的 `ref` 拿到。
+
+| 方法 | 说明 |
+| --- | --- |
+| `open()` | 打开控制台。 |
+| `close()` | 关闭控制台。 |
+| `isOpen()` | 返回控制台是否处于打开状态。 |
+
+## 监视器初始化
+
+从 `lynx-console/setup` 引入，在应用入口调用。
+
+| 函数 | 说明 |
+| --- | --- |
+| `initLogMonitor()` | 捕获 `console.log`、`console.error` 等输出。 |
+| `initMainThreadConsole()` | 捕获主线程的控制台输出。需要先调用 `initLogMonitor()`。 |
+| `initNetworkMonitor()` | 拦截并记录 `fetch` 请求。 |
+| `initPerformanceMonitor()` | 收集性能指标。 |
+
+只有初始化过的监视器才会渲染对应的标签页。

--- a/docs/src/zh/api/index.md
+++ b/docs/src/zh/api/index.md
@@ -19,8 +19,8 @@ description: props、console handle 和监视器初始化函数。
 | 属性 | 类型 | 说明 |
 | --- | --- | --- |
 | `key` | `string` | 标签页的唯一标识。 |
-| `label` | `string` | 标签页的文字。 |
-| `renderContent` | `() => ReactNode` | 渲染标签页内容。 |
+| `label` | `string` | 标签页的显示文字。 |
+| `renderContent` | `() => ReactNode` | 渲染标签页的内容。 |
 
 ## `LynxConsoleHandle`
 
@@ -43,4 +43,4 @@ description: props、console handle 和监视器初始化函数。
 | `initNetworkMonitor()` | 拦截并记录 `fetch` 请求。 |
 | `initPerformanceMonitor()` | 收集性能指标。 |
 
-只有初始化过的监视器才会渲染对应的标签页。
+只有初始化过的监视器，才会显示对应的标签页。

--- a/docs/src/zh/guide/customizing.md
+++ b/docs/src/zh/guide/customizing.md
@@ -7,7 +7,7 @@ description: 自定义标签页、用代码打开控制台，以及按钮位置�
 
 ## 添加自己的标签页
 
-可以把任何你需要的调试信息放进控制台的标签页里。
+任何你需要的调试信息，都可以放进控制台的一个标签页里。
 
 ```tsx
 import LynxConsole, { type CustomTab } from 'lynx-console';
@@ -29,9 +29,9 @@ function App() {
 }
 ```
 
-## 用代码控制控制台
+## 用代码开关控制台
 
-`LynxConsoleHandle` 让你自己打开和关闭面板。
+通过 `LynxConsoleHandle` 可以自己打开和关闭面板。
 
 ```tsx
 import { type LynxConsoleHandle } from 'lynx-console';
@@ -60,9 +60,9 @@ function App() {
 }
 ```
 
-把 `close()` 接到返回键处理里，就能用返回键关掉控制台。
+把 `close()` 接到返回键的处理逻辑里，按返回键就能关掉控制台。
 
-## 放置悬浮按钮
+## 悬浮按钮的位置
 
 默认是 `{ right: 16, bottom: 84 }`，四个方向互相独立：
 
@@ -70,7 +70,7 @@ function App() {
 <LynxConsole initialPosition={{ top: 50, left: 16 }} />
 ```
 
-用户拖动过按钮之后，拖动后的位置优先于 `initialPosition`。
+用户拖动过按钮之后，拖出来的位置会盖过 `initialPosition`。
 
 ## 主题和安全区域
 

--- a/docs/src/zh/guide/customizing.md
+++ b/docs/src/zh/guide/customizing.md
@@ -1,0 +1,81 @@
+---
+title: 自定义标签页与 ref
+description: 自定义标签页、用代码打开控制台，以及按钮位置。
+---
+
+# 自定义标签页与 ref
+
+## 添加自己的标签页
+
+可以把任何你需要的调试信息放进控制台的标签页里。
+
+```tsx
+import LynxConsole, { type CustomTab } from 'lynx-console';
+
+const customTabs: CustomTab[] = [
+  {
+    key: 'debug',
+    label: 'Debug',
+    renderContent: () => <text>自定义调试内容</text>,
+  },
+];
+
+function App() {
+  return (
+    <view>
+      <LynxConsole customTabs={customTabs} />
+    </view>
+  );
+}
+```
+
+## 用代码控制控制台
+
+`LynxConsoleHandle` 让你自己打开和关闭面板。
+
+```tsx
+import { type LynxConsoleHandle } from 'lynx-console';
+import { lazy, useRef } from '@lynx-js/react';
+
+const LynxConsole = lazy(() => import('lynx-console'));
+
+function App() {
+  const consoleRef = useRef<LynxConsoleHandle>(null);
+
+  const toggleConsole = () => {
+    if (consoleRef.current?.isOpen()) {
+      consoleRef.current.close();
+    } else {
+      consoleRef.current?.open();
+    }
+  };
+
+  return (
+    <view>
+      <Suspense>
+        <LynxConsole ref={consoleRef} />
+      </Suspense>
+    </view>
+  );
+}
+```
+
+把 `close()` 接到返回键处理里，就能用返回键关掉控制台。
+
+## 放置悬浮按钮
+
+默认是 `{ right: 16, bottom: 84 }`，四个方向互相独立：
+
+```tsx
+<LynxConsole initialPosition={{ top: 50, left: 16 }} />
+```
+
+用户拖动过按钮之后，拖动后的位置优先于 `initialPosition`。
+
+## 主题和安全区域
+
+```tsx
+<LynxConsole theme="dark" safeAreaInsetBottom="34px" />
+```
+
+`safeAreaInsetBottom` 默认是 `"50px"`。

--- a/docs/src/zh/guide/demo.mdx
+++ b/docs/src/zh/guide/demo.mdx
@@ -48,7 +48,7 @@ yarn build
 yarn dev:example
 ```
 
-想在浏览器里跑，还要构建 Web 宿主壳：
+想在浏览器里跑，还要把 Web 宿主页面也构建出来：
 
 ```bash
 yarn build && yarn build:example

--- a/docs/src/zh/guide/demo.mdx
+++ b/docs/src/zh/guide/demo.mdx
@@ -1,0 +1,63 @@
+---
+title: 体验演示
+description: 在浏览器、Lynx Explorer 或本地运行示例。
+---
+
+# 体验演示
+
+示例应用和这份文档部署在一起，所以你可以马上试用 `lynx-console`。
+
+## 在浏览器里
+
+可以直接打开示例的 Web 版本。
+
+<a href="/demo/" target="_blank" rel="noreferrer"><strong>打开 Web 演示 →</strong></a>
+
+点一下 **LynxConsole** 按钮，再按任意一个测试按钮，面板里马上就会有记录。
+
+## 在真机上用 Lynx Explorer
+
+安装 [Lynx Explorer](https://lynxjs.org/guide/start/quick-start.html#via-lynx-explorer-app)
+应用，然后扫描这个二维码：
+
+<img src="/lynx-explorer-qr.svg" alt="Lynx Explorer 演示 bundle 的二维码" width="180" height="180" style={{ background: '#fff', padding: '8px', borderRadius: '8px' }} />
+
+正在手机上看？直接打开：
+
+<a href="lynx://open?url=https%3A%2F%2Flynx-console.pages.dev%2Fmain.lynx.bundle%3Ffullscreen%3Dtrue"><strong>用 Lynx Explorer 打开 →</strong></a>
+
+```
+https://lynx-console.pages.dev/main.lynx.bundle?fullscreen=true
+```
+
+| URL | 说明 |
+| --- | --- |
+| <a href="/main.lynx.bundle"><code>/main.lynx.bundle</code></a> | 给原生 Lynx 运行时（Lynx Explorer）用的示例 bundle。 |
+| <a href="/main.web.bundle"><code>/main.web.bundle</code></a> | 同一个示例，为 Lynx Web Platform 构建的版本。 |
+| <a href="/demo/"><code>/demo/</code></a> | 加载 `/main.web.bundle` 的 `<lynx-view>` 宿主页面。 |
+
+## 在本地运行
+
+```bash
+git clone https://github.com/daangn/lynx-console.git
+cd lynx-console
+yarn install
+
+# 先构建包，再启动示例，终端里会出现二维码
+yarn build
+yarn dev:example
+```
+
+想在浏览器里跑，还要构建 Web 宿主壳：
+
+```bash
+yarn build && yarn build:example
+yarn workspace lynx-console-test build:web
+```
+
+想把文档和演示一起跑起来：
+
+```bash
+yarn build && yarn build:example
+yarn dev:docs
+```

--- a/docs/src/zh/guide/getting-started.md
+++ b/docs/src/zh/guide/getting-started.md
@@ -1,0 +1,104 @@
+---
+title: 快速开始
+description: 安装、配置构建、初始化监视器、渲染控制台。
+---
+
+# 快速开始
+
+## 安装
+
+```bash
+yarn add lynx-console
+```
+
+### Peer dependencies
+
+```bash
+yarn add @lynx-js/react @lynx-js/types
+yarn add -D @types/react
+```
+
+## 0. 配置构建（必需）
+
+在 `lynx.config.ts` 里加上：
+
+```typescript title="lynx.config.ts"
+export default defineConfig({
+  source: {
+    define: {
+      console: 'globalThis.console',
+      fetch: 'lynx.fetch',
+    },
+  },
+});
+```
+
+- **`console`** — iOS 的 JSC 注入的 `console` 并*不是* `globalThis.console`。不做这个替换，
+  `initLogMonitor()` 在 iOS 上不会生效。
+- **`fetch`** — 取决于你的构建配置，不替换成 `lynx.fetch` 的话网络请求可能不会被记录。
+
+## 1. 初始化监视器
+
+在应用入口调用，要在 `LynxConsole` 渲染**之前**。
+
+```typescript title="src/index.tsx"
+import {
+  initLogMonitor,
+  initMainThreadConsole,
+  initNetworkMonitor,
+  initPerformanceMonitor,
+} from 'lynx-console/setup';
+
+initLogMonitor();
+initMainThreadConsole();
+initNetworkMonitor();
+initPerformanceMonitor();
+```
+
+:::warning
+主线程控制台建立在日志监视器之上，所以 `initLogMonitor()` 必须在 `initMainThreadConsole()`
+之前调用。
+:::
+
+没有初始化的监视器，不会渲染对应的标签页。
+
+## 2. 渲染组件
+
+```tsx title="src/App.tsx"
+import LynxConsole from 'lynx-console';
+
+function App() {
+  return (
+    <view>
+      {/* 你的应用 */}
+      <LynxConsole theme="light" safeAreaInsetBottom="34px" />
+    </view>
+  );
+}
+```
+
+也可以用 `lazy` 把它从主包里拆出去：
+
+```tsx title="src/App.tsx"
+import { lazy, Suspense } from '@lynx-js/react';
+
+const LynxConsole = lazy(() => import('lynx-console'));
+
+function App() {
+  return (
+    <view>
+      {/* 你的应用 */}
+      <Suspense>
+        <LynxConsole theme="light" safeAreaInsetBottom="34px" />
+      </Suspense>
+    </view>
+  );
+}
+```
+
+运行应用，点一下悬浮按钮，面板就打开了。
+
+## 下一步
+
+- [自定义标签页与 ref](/zh/guide/customizing) — 添加自己的标签页，或者用代码打开控制台。
+- [API 参考](/zh/api/) — 所有 prop 和函数都在一张表里。

--- a/docs/src/zh/guide/getting-started.md
+++ b/docs/src/zh/guide/getting-started.md
@@ -33,13 +33,13 @@ export default defineConfig({
 });
 ```
 
-- **`console`** — iOS 的 JSC 注入的 `console` 并*不是* `globalThis.console`。不做这个替换，
+- **`console`** — iOS 上 JSC 注入的 `console` 并*不是* `globalThis.console`。不做这个替换的话，
   `initLogMonitor()` 在 iOS 上不会生效。
-- **`fetch`** — 取决于你的构建配置，不替换成 `lynx.fetch` 的话网络请求可能不会被记录。
+- **`fetch`** — 视构建配置而定，不替换成 `lynx.fetch` 的话，网络请求可能不会被记录。
 
 ## 1. 初始化监视器
 
-在应用入口调用，要在 `LynxConsole` 渲染**之前**。
+在应用入口调用这些函数，而且要在 `LynxConsole` 渲染**之前**。
 
 ```typescript title="src/index.tsx"
 import {
@@ -60,7 +60,7 @@ initPerformanceMonitor();
 之前调用。
 :::
 
-没有初始化的监视器，不会渲染对应的标签页。
+没有初始化的监视器，对应的标签页不会显示。
 
 ## 2. 渲染组件
 

--- a/docs/src/zh/guide/introduction.md
+++ b/docs/src/zh/guide/introduction.md
@@ -1,0 +1,32 @@
+---
+title: 介绍
+description: lynx-console 是什么、能看到什么、能跑在哪里。
+---
+
+# 介绍
+
+`lynx-console` 是一个面向 [Lynx](https://lynxjs.org) 应用的应用内开发者控制台。
+不用连调试器，就能在真机上查看控制台日志、`fetch` 流量和性能指标。
+
+## 你能得到什么
+
+- **控制台** — `console.log`、`console.warn`、`console.error` 的输出，支持级别过滤、
+  关键字搜索和 REPL。
+- **主线程控制台** — `'main thread'` 函数里的日志同样会被捕获。
+- **网络** — 每一个 `fetch` 请求的方法、状态码、请求头、请求体和响应。
+- **性能** — FCP 以及其他 Lynx 性能条目，包含原始的 entry 数据。
+
+没有初始化的监视器，不会渲染对应的标签页。
+
+## 支持的平台
+
+| 平台 | 状态 |
+| --- | --- |
+| iOS / Android（Lynx 运行时） | 支持。iOS 需要在[构建时替换 `console`](/zh/guide/getting-started#0-配置构建必需)。 |
+| [Lynx Web Platform](https://lynxjs.org/guide/start/quick-start.html) | 支持 — 本站的[在线演示](/zh/guide/demo)就跑在上面。 |
+
+## 下一步
+
+- [快速开始](/zh/guide/getting-started) — 安装并渲染控制台。
+- [体验演示](/zh/guide/demo) — 在浏览器或 Lynx Explorer 里运行示例。
+- [API 参考](/zh/api/) — props、handle 和监视器初始化函数。

--- a/docs/src/zh/guide/introduction.md
+++ b/docs/src/zh/guide/introduction.md
@@ -5,18 +5,18 @@ description: lynx-console 是什么、能看到什么、能跑在哪里。
 
 # 介绍
 
-`lynx-console` 是一个面向 [Lynx](https://lynxjs.org) 应用的应用内开发者控制台。
+`lynx-console` 是一个跑在 [Lynx](https://lynxjs.org) 应用内部的开发者控制台。
 不用连调试器，就能在真机上查看控制台日志、`fetch` 流量和性能指标。
 
-## 你能得到什么
+## 功能一览
 
 - **控制台** — `console.log`、`console.warn`、`console.error` 的输出，支持级别过滤、
   关键字搜索和 REPL。
 - **主线程控制台** — `'main thread'` 函数里的日志同样会被捕获。
 - **网络** — 每一个 `fetch` 请求的方法、状态码、请求头、请求体和响应。
-- **性能** — FCP 以及其他 Lynx 性能条目，包含原始的 entry 数据。
+- **性能** — FCP 以及其他 Lynx 性能条目，还带上原始的 entry 数据。
 
-没有初始化的监视器，不会渲染对应的标签页。
+没有初始化的监视器，对应的标签页不会显示。
 
 ## 支持的平台
 

--- a/docs/src/zh/index.md
+++ b/docs/src/zh/index.md
@@ -1,10 +1,10 @@
 ---
 pageType: home
-titleSuffix: Lynx 应用的应用内开发者控制台
+titleSuffix: 可以嵌入 Lynx 应用的开发者控制台
 
 hero:
   name: lynx-console
-  tagline: 一个悬浮按钮，在运行中的 Lynx 应用之上打开控制台、网络和性能面板。不用电脑也能看日志。
+  tagline: 点一下悬浮按钮，控制台、网络和性能面板就浮在运行中的 Lynx 应用上。不用电脑也能看日志。
   actions:
     - theme: brand
       text: 快速开始
@@ -18,5 +18,5 @@ features:
   - title: 记录每一个 fetch
     details: 方法、状态码、请求头、请求体、响应。从初始化那一刻开始记录。
   - title: 自定义标签页
-    details: 可以把任何你需要的调试信息放进控制台的标签页里。
+    details: 任何你需要的调试信息，都可以放进控制台的一个标签页里。
 ---

--- a/docs/src/zh/index.md
+++ b/docs/src/zh/index.md
@@ -1,0 +1,22 @@
+---
+pageType: home
+titleSuffix: Lynx 应用的应用内开发者控制台
+
+hero:
+  name: lynx-console
+  tagline: 一个悬浮按钮，在运行中的 Lynx 应用之上打开控制台、网络和性能面板。不用电脑也能看日志。
+  actions:
+    - theme: brand
+      text: 快速开始
+      link: /zh/guide/getting-started
+
+features:
+  - title: 主线程日志也能看
+    details: 写在 'main thread' 函数里的 console.log，会和其他日志出现在同一个列表里。
+  - title: 应用内的 REPL
+    details: 在日志标签页底部输入代码，就能在应用里直接执行。
+  - title: 记录每一个 fetch
+    details: 方法、状态码、请求头、请求体、响应。从初始化那一刻开始记录。
+  - title: 自定义标签页
+    details: 可以把任何你需要的调试信息放进控制台的标签页里。
+---

--- a/package/README.md
+++ b/package/README.md
@@ -1,4 +1,4 @@
-[한국어](https://github.com/daangn/lynx-console/blob/main/package/README_ko.md) | English
+English | [한국어](https://github.com/daangn/lynx-console/blob/main/package/README_ko.md) | [简体中文](https://github.com/daangn/lynx-console/blob/main/package/README_zh.md)
 
 # lynx-console
 

--- a/package/README_ko.md
+++ b/package/README_ko.md
@@ -1,4 +1,4 @@
-한국어 | [English](https://github.com/daangn/lynx-console/blob/main/package/README.md)
+[English](https://github.com/daangn/lynx-console/blob/main/package/README.md) | 한국어 | [简体中文](https://github.com/daangn/lynx-console/blob/main/package/README_zh.md)
 
 # lynx-console
 

--- a/package/README_zh.md
+++ b/package/README_zh.md
@@ -1,0 +1,214 @@
+[English](https://github.com/daangn/lynx-console/blob/main/package/README.md) | [한국어](https://github.com/daangn/lynx-console/blob/main/package/README_ko.md) | 简体中文
+
+# lynx-console
+
+可以嵌入 Lynx 应用的应用内开发者控制台。实时查看控制台日志、网络请求和性能指标。
+
+📖 **[文档站点](https://lynx-console.pages.dev/zh/)** — 指南、API 参考，以及可以在浏览器里直接运行的在线演示。
+
+## 演示
+
+在浏览器里打开 **[lynx-console.pages.dev](https://lynx-console.pages.dev/zh/)** 就能试用 — 首页内嵌了跑在 Lynx Web Platform 上的示例应用。
+
+https://github.com/user-attachments/assets/dcd874bf-ff2e-4a98-ae03-d83de5fae31c
+
+<img width="492" height="492" alt="lynxconsoleqrcodefullscreen" src="https://github.com/user-attachments/assets/ca735109-c531-44ce-bf81-3a61a61ac2e4" />
+
+用 [Lynx Explorer](https://lynxjs.org/guide/start/quick-start.html#via-lynx-explorer-app) 应用扫描上面的二维码，就能体验演示。
+
+## 功能
+
+- **控制台日志** — 实时查看 `console.log`、`console.error` 等输出。支持级别过滤、关键字搜索、清空日志，以及内置 REPL
+- **主线程控制台** — 主线程的日志会和后台线程的日志一起被捕获
+
+https://github.com/user-attachments/assets/539fe31a-aca4-468d-b673-3b070b21cd08
+
+- **网络监视器** — 查看 `fetch` 请求的方法、状态码、请求头、请求体和响应
+
+https://github.com/user-attachments/assets/edda4778-ab8d-4cb9-a3c5-bd8c42c81bde
+
+- **性能监视器** — 追踪 FCP（First Contentful Paint）等性能指标，并附带原始 entry 数据
+
+https://github.com/user-attachments/assets/d231bdf5-71bb-483f-9bdb-5843279c1308
+
+- **悬浮按钮** — 显示最新的 FCP 数值；点击打开控制台，长按拖动可以改变位置
+- **可调整面板** — 拖动手柄调整控制台面板高度（200–700px）；向下滑动即可关闭
+- **标签页自动隐藏** — 只显示已初始化的监视器的标签页，没有初始化的会自动隐藏
+- **自定义标签页** — 通过 `customTabs` prop 把自己的标签页加进控制台
+- 支持**浅色/深色主题**
+
+## 安装
+
+```bash
+yarn add lynx-console
+```
+
+### Peer Dependencies
+
+```bash
+yarn add @lynx-js/react @lynx-js/types
+yarn add -D @types/react
+```
+
+## 使用方法
+
+### 0. 配置构建（必需）
+
+在 `lynx.config.ts` 里加上：
+
+```typescript
+export default defineConfig({
+  source: {
+    define: {
+      console: "globalThis.console",
+      fetch: "lynx.fetch",
+    },
+  },
+});
+```
+
+- **`console`** — 在 iOS 上，Lynx 运行时（JSC）会注入一个独立于 `globalThis.console` 的 `console` 对象。不在构建时替换这个标识符，`initLogMonitor()` 打的补丁在 iOS 上不会生效。
+- **`fetch`** — 取决于你的构建配置，不替换成 `lynx.fetch` 的话网络请求可能不会被记录。
+
+### 1. 初始化监视器
+
+在应用入口调用监视函数。这段设置必须在 `LynxConsole` 组件渲染**之前**执行。
+
+```typescript
+import {
+  initLogMonitor,
+  initMainThreadConsole,
+  initNetworkMonitor,
+  initPerformanceMonitor,
+} from "lynx-console/setup";
+
+initLogMonitor();
+initMainThreadConsole();
+initNetworkMonitor();
+initPerformanceMonitor();
+```
+
+> **注意：** 主线程控制台依赖日志监视器，所以 `initMainThreadConsole()` 必须在 `initLogMonitor()` 之后调用。
+
+### 2. 渲染组件
+
+```tsx
+import LynxConsole from "lynx-console";
+
+function App() {
+  return (
+    <view>
+      {/* 你的应用内容 */}
+      <LynxConsole theme="light" safeAreaInsetBottom="34px" />
+    </view>
+  );
+}
+```
+
+```tsx
+const LynxConsole = lazy(() => import("lynx-console"));
+
+function App() {
+  return (
+    <view>
+      {/* 你的应用内容 */}
+      <Suspense>
+        <LynxConsole theme="light" safeAreaInsetBottom="34px" />
+      </Suspense>
+    </view>
+  );
+}
+```
+
+### 添加自定义标签页
+
+可以用 `customTabs` prop 把自己的标签页加进控制台。
+
+```tsx
+import LynxConsole, { type CustomTab } from "lynx-console";
+
+const customTabs: CustomTab[] = [
+  {
+    key: "debug",
+    label: "Debug",
+    renderContent: () => <text>自定义调试内容</text>,
+  },
+];
+
+function App() {
+  return (
+    <view>
+      <LynxConsole customTabs={customTabs} />
+    </view>
+  );
+}
+```
+
+### 用 ref 控制
+
+通过 `LynxConsoleHandle` 可以用代码打开和关闭控制台。
+
+```tsx
+import { type LynxConsoleHandle } from "lynx-console";
+import { useRef } from "@lynx-js/react";
+
+const LynxConsole = lazy(() => import("lynx-console"));
+
+function App() {
+  const consoleRef = useRef<LynxConsoleHandle>(null);
+
+  const toggleConsole = () => {
+    if (consoleRef.current?.isOpen()) {
+      consoleRef.current.close();
+    } else {
+      consoleRef.current?.open();
+    }
+  };
+
+  return (
+    <view>
+      <Suspense>
+        <LynxConsole ref={consoleRef} />
+      </Suspense>
+    </view>
+  );
+}
+```
+
+也可以和返回键处理逻辑结合，让用户按返回键时关掉控制台。
+
+## API
+
+### `LynxConsole` Props
+
+| Prop                  | 类型                | 默认值      | 说明                             |
+| --------------------- | ------------------- | ----------- | -------------------------------- |
+| `theme`               | `"light" \| "dark"` | `"light"`   | 控制台 UI 主题                   |
+| `safeAreaInsetBottom` | `string`            | `"50px"`    | 底部安全区域内边距               |
+| `customTabs`          | `CustomTab[]`       | `undefined` | 要在控制台里额外显示的自定义标签页 |
+| `initialPosition`     | `{ top?: number; left?: number; right?: number; bottom?: number }` | `{ right: 16, bottom: 84 }` | 悬浮按钮的初始位置（px）。四个方向互相独立，所以可以吸附到任意一个角（例如 `{ top: 50, left: 16 }`）。同时设置 `top`/`bottom`（或 `left`/`right`）时，`top`/`left` 生效。用户拖动过按钮之后，保存下来的位置优先。 |
+
+### `CustomTab`
+
+| 属性            | 类型              | 说明                   |
+| --------------- | ----------------- | ---------------------- |
+| `key`           | `string`          | 标签页的唯一标识       |
+| `label`         | `string`          | 标签页的文字           |
+| `renderContent` | `() => ReactNode` | 渲染标签页内容的函数   |
+
+### `LynxConsoleHandle`
+
+| 方法       | 说明                     |
+| ---------- | ------------------------ |
+| `open()`   | 打开控制台               |
+| `close()`  | 关闭控制台               |
+| `isOpen()` | 返回控制台是否处于打开状态 |
+
+### 监视器初始化函数
+
+| 函数                       | 说明                                    |
+| -------------------------- | --------------------------------------- |
+| `initLogMonitor()`         | 捕获 `console.log`、`console.error` 等  |
+| `initMainThreadConsole()`  | 捕获主线程的控制台输出                  |
+| `initNetworkMonitor()`     | 拦截并记录 `fetch` 请求                 |
+| `initPerformanceMonitor()` | 收集性能指标                            |

--- a/package/README_zh.md
+++ b/package/README_zh.md
@@ -2,7 +2,7 @@
 
 # lynx-console
 
-可以嵌入 Lynx 应用的应用内开发者控制台。实时查看控制台日志、网络请求和性能指标。
+可以嵌入 Lynx 应用的开发者控制台。实时查看控制台日志、网络请求和性能指标。
 
 📖 **[文档站点](https://lynx-console.pages.dev/zh/)** — 指南、API 参考，以及可以在浏览器里直接运行的在线演示。
 
@@ -18,7 +18,7 @@ https://github.com/user-attachments/assets/dcd874bf-ff2e-4a98-ae03-d83de5fae31c
 
 ## 功能
 
-- **控制台日志** — 实时查看 `console.log`、`console.error` 等输出。支持级别过滤、关键字搜索、清空日志，以及内置 REPL
+- **控制台日志** — 实时查看 `console.log`、`console.error` 等输出。支持级别过滤、关键字搜索、清空日志，还内置了 REPL
 - **主线程控制台** — 主线程的日志会和后台线程的日志一起被捕获
 
 https://github.com/user-attachments/assets/539fe31a-aca4-468d-b673-3b070b21cd08
@@ -33,8 +33,8 @@ https://github.com/user-attachments/assets/d231bdf5-71bb-483f-9bdb-5843279c1308
 
 - **悬浮按钮** — 显示最新的 FCP 数值；点击打开控制台，长按拖动可以改变位置
 - **可调整面板** — 拖动手柄调整控制台面板高度（200–700px）；向下滑动即可关闭
-- **标签页自动隐藏** — 只显示已初始化的监视器的标签页，没有初始化的会自动隐藏
-- **自定义标签页** — 通过 `customTabs` prop 把自己的标签页加进控制台
+- **标签页自动隐藏** — 只显示已初始化的监视器对应的标签页，没有初始化的不会出现
+- **自定义标签页** — 通过 `customTabs` prop 把自己的标签页加到控制台里
 - 支持**浅色/深色主题**
 
 ## 安装
@@ -67,12 +67,12 @@ export default defineConfig({
 });
 ```
 
-- **`console`** — 在 iOS 上，Lynx 运行时（JSC）会注入一个独立于 `globalThis.console` 的 `console` 对象。不在构建时替换这个标识符，`initLogMonitor()` 打的补丁在 iOS 上不会生效。
-- **`fetch`** — 取决于你的构建配置，不替换成 `lynx.fetch` 的话网络请求可能不会被记录。
+- **`console`** — 在 iOS 上，Lynx 运行时（JSC）会注入一个独立于 `globalThis.console` 的 `console` 对象。不在构建时替换这个标识符的话，`initLogMonitor()` 打的补丁在 iOS 上不会生效。
+- **`fetch`** — 视构建配置而定，不替换成 `lynx.fetch` 的话，网络请求可能不会被记录。
 
 ### 1. 初始化监视器
 
-在应用入口调用监视函数。这段设置必须在 `LynxConsole` 组件渲染**之前**执行。
+在应用入口调用这些监视函数。这段初始化必须在 `LynxConsole` 组件渲染**之前**执行。
 
 ```typescript
 import {
@@ -146,7 +146,7 @@ function App() {
 
 ### 用 ref 控制
 
-通过 `LynxConsoleHandle` 可以用代码打开和关闭控制台。
+通过 `LynxConsoleHandle` 可以用代码开关控制台。
 
 ```tsx
 import { type LynxConsoleHandle } from "lynx-console";
@@ -175,7 +175,7 @@ function App() {
 }
 ```
 
-也可以和返回键处理逻辑结合，让用户按返回键时关掉控制台。
+也可以和返回键的处理逻辑结合，让用户按返回键时关掉控制台。
 
 ## API
 
@@ -194,7 +194,7 @@ function App() {
 | --------------- | ----------------- | ---------------------- |
 | `key`           | `string`          | 标签页的唯一标识       |
 | `label`         | `string`          | 标签页的文字           |
-| `renderContent` | `() => ReactNode` | 渲染标签页内容的函数   |
+| `renderContent` | `() => ReactNode` | 渲染标签页内容的函数     |
 
 ### `LynxConsoleHandle`
 


### PR DESCRIPTION
## 요약

README 와 문서 사이트에 중국어(`zh`) 버전을 추가했어요. 라우트 접두사는 Lynx 공식문서와 같은 `/zh/` 예요.

## 변경 내용

**README**
- `package/README_zh.md` 추가 (루트 `README_zh.md` 는 심링크)
- 세 README 상단 언어 전환 줄을 `English | 한국어 | 简体中文` 로 통일

**문서 사이트**
- `docs/src/zh/` 에 홈 · 소개 · 시작하기 · 커스텀 탭 · 데모 · API 레퍼런스 6개 추가
- `rspress.config.ts` 에 `zh` 로케일 추가 (라벨 `简体中文`, nav · 사이드바 · outlineTitle · editLink)
- 홈 컴포넌트(`HomeHero` · `QuickStart`)의 문구 사전에 `zh` 추가

**리팩터링**
- hreflang · og:locale · sitemap 생성이 en/ko 두 개로 하드코딩돼 있어서, 로케일 목록을 `docs/siteMeta.mjs` 의 `LOCALES` 한 곳으로 모으고 언어 수에 의존하지 않게 바꿨어요

## 확인한 것

- `yarn check` 통과
- `yarn build:site` 통과 (dead link 검사 포함), sitemap 12 → 18 URL
- `/zh/` 홈 · 가이드 렌더 확인, 중국어 앵커 링크(`#0-配置构建必需`)가 실제 heading id 와 일치
- en/ko 의 canonical · hreflang 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)
