### PR TITLE
feat: 중국어 시작하기에도 패키지 매니저 탭 적용

### DIFF
--- a/docs/src/zh/guide/getting-started.mdx
+++ b/docs/src/zh/guide/getting-started.mdx
@@ -3,20 +3,31 @@ title: 快速开始
 description: 安装、配置构建、初始化监视器、渲染控制台。
 ---
 
+import { PackageManagerTabs } from '@theme';
+
 # 快速开始
 
 ## 安装
 
-```bash
-yarn add lynx-console
-```
+<PackageManagerTabs
+  command={{
+    npm: 'npm install lynx-console',
+    yarn: 'yarn add lynx-console',
+    pnpm: 'pnpm add lynx-console',
+    bun: 'bun add lynx-console',
+  }}
+/>
 
 ### Peer dependencies
 
-```bash
-yarn add @lynx-js/react @lynx-js/types
-yarn add -D @types/react
-```
+<PackageManagerTabs
+  command={{
+    npm: 'npm install @lynx-js/react @lynx-js/types\nnpm install -D @types/react',
+    yarn: 'yarn add @lynx-js/react @lynx-js/types\nyarn add -D @types/react',
+    pnpm: 'pnpm add @lynx-js/react @lynx-js/types\npnpm add -D @types/react',
+    bun: 'bun add @lynx-js/react @lynx-js/types\nbun add -D @types/react',
+  }}
+/>
 
 ## 0. 配置构建（必需）
 


### PR DESCRIPTION
## 요약

중국어 문서의 시작하기 페이지에만 패키지 매니저 탭이 빠져 있었어요. #65 브랜치를 #64 이전 커밋에서 갈라져 나와 작업한 탓이에요. en/ko 와 똑같이 맞췄어요.

## 변경 내용

- `docs/src/zh/guide/getting-started.md` → `.mdx` 로 이동 (JSX 사용, 라우트는 그대로)
- 설치 · Peer dependencies 블록을 `PackageManagerTabs` 로 교체 (npm / yarn / pnpm / bun)
- `command` 는 en/ko 와 동일하게 객체로 전달 (문자열이면 pnpm 이 `pnpm install <pkg>` 로 나와요)

## 확인한 것

- `yarn check` 통과
- `yarn build:site` 통과 (dead link 검사 포함)
- 렌더된 HTML 에서 pnpm · bun 등장 횟수가 en / ko / zh 모두 동일
- 브라우저에서 탭 전환 확인 — 두 블록이 `groupId` 로 같이 바뀌고, `pnpm add lynx-console` 로 나와요
- 소개 문서가 거는 `#0-配置构建必需` 앵커도 그대로 살아 있어요

🤖 Generated with [Claude Code](https://claude.com/claude-code)
