### PR TITLE
fix: web에서 플로팅 버튼 드래그 지원

### DIFF
--- a/.changeset/web-drag-mouse-support.md
+++ b/.changeset/web-drag-mouse-support.md
@@ -1,0 +1,13 @@
+---
+"lynx-console": patch
+---
+
+web에서 플로팅 버튼 드래그 지원
+
+데스크톱 브라우저는 touch 이벤트를 만들지 않아 `catchtouchstart/move/end`에만 의존하던 드래그가 web에서 아예 시작되지 않던 문제를 고쳤어요. 네이티브 touch 경로는 그대로예요.
+
+- web에서 `mousedown/mousemove/mouseup`으로 동일한 드래그 상태 머신을 구동 (`useDrag`)
+- 커서가 버튼 밖으로 벗어나도 포인터를 계속 추적하도록, 누르고 있는 동안만 전체 화면 오버레이를 렌더 (`FloatingButton`)
+- web의 touch 이벤트는 네이티브와 달리 `detail.x/y`가 없어 `changedTouches` 좌표를 사용하도록 변경 (`useDrag`)
+- 드래그 직후 이어지는 `click`으로 콘솔이 열리지 않도록 기존 `recentDrag` 가드를 마우스 경로에도 적용, `touchend`와 `bindtap`이 탭을 중복 처리하지 않도록 정리 (`useDrag`)
+- reload 버튼을 누를 때 드래그가 시작되지 않도록 web에서 `mousedown`도 차단 (`FloatingButton`)

--- a/package/src/components/FloatingButton.css
+++ b/package/src/components/FloatingButton.css
@@ -8,6 +8,15 @@
   overflow: visible;
 }
 
+.fb-dragOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 9996;
+}
+
 .fb-button {
   position: relative;
   overflow: hidden;

--- a/package/src/components/FloatingButton.tsx
+++ b/package/src/components/FloatingButton.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "@lynx-js/react";
 import { type InitialPosition, useDrag } from "../hooks/useDrag";
+import { isWebPlatform } from "../shared/isWebPlatform";
 import { useThemeColors } from "../styles/ThemeContext";
 import { duration } from "../styles/theme";
 import "./FloatingButton.css";
@@ -33,9 +34,10 @@ export const FloatingButton = ({
   initialPosition,
 }: FloatingButtonProps) => {
   const colors = useThemeColors();
-  const { phase, positionStyle, handlers } = useDrag(bindtap, {
-    initialPosition,
-  });
+  const { phase, positionStyle, handlers, dragOverlayHandlers } = useDrag(
+    bindtap,
+    { initialPosition },
+  );
 
   const handleReload = () => {
     try {
@@ -49,36 +51,48 @@ export const FloatingButton = ({
 
   const isDragging = phase === "dragging";
 
+  // reload 버튼을 누를 때 wrapper의 드래그가 시작되지 않도록 이벤트를 막아요.
+  const reloadButtonHandlers = isWebPlatform
+    ? { catchmousedown: () => {} }
+    : {};
+
   return (
-    <view
-      className={"fb-wrapper"}
-      style={{
-        ...positionStyle,
-        transform: isDragging ? "scale(1.05)" : "scale(1)",
-        transition: `transform ${duration.d4} cubic-bezier(0.4, 0, 0.2, 1)`,
-      }}
-      {...handlers}
-    >
+    <>
+      {/* 드래그 중 커서가 버튼 밖으로 나가도 mousemove/mouseup을 계속 받기 위한 오버레이예요 */}
+      {dragOverlayHandlers && (
+        <view className={"fb-dragOverlay"} {...dragOverlayHandlers} />
+      )}
       <view
-        className={"fb-button"}
-        style={{ backgroundColor: colors.palette.green600 }}
+        className={"fb-wrapper"}
+        style={{
+          ...positionStyle,
+          transform: isDragging ? "scale(1.05)" : "scale(1)",
+          transition: `transform ${duration.d4} cubic-bezier(0.4, 0, 0.2, 1)`,
+        }}
+        {...handlers}
       >
-        {children}
-        <view className={"fb-shineOverlay"} style={SHINE_STYLES[phase]} />
-      </view>
-      <view
-        className={"fb-reloadButton"}
-        style={{ backgroundColor: colors.palette.green600 }}
-        catchtouchstart={() => {}}
-        bindtap={handleReload}
-      >
-        <text
-          className={"fb-reloadIcon"}
-          style={{ color: colors.palette.staticWhite }}
+        <view
+          className={"fb-button"}
+          style={{ backgroundColor: colors.palette.green600 }}
         >
-          {"\u21BB"}
-        </text>
+          {children}
+          <view className={"fb-shineOverlay"} style={SHINE_STYLES[phase]} />
+        </view>
+        <view
+          className={"fb-reloadButton"}
+          style={{ backgroundColor: colors.palette.green600 }}
+          catchtouchstart={() => {}}
+          {...reloadButtonHandlers}
+          bindtap={handleReload}
+        >
+          <text
+            className={"fb-reloadIcon"}
+            style={{ color: colors.palette.staticWhite }}
+          >
+            {"\u21BB"}
+          </text>
+        </view>
       </view>
-    </view>
+    </>
   );
 };

--- a/package/src/hooks/useDrag.ts
+++ b/package/src/hooks/useDrag.ts
@@ -24,6 +24,41 @@ interface ResolvedAnchors {
   y: number;
 }
 
+interface Point {
+  x: number;
+  y: number;
+}
+
+// web platform은 touch/mouse 이벤트를 W3C 형태로 그대로 넘겨줘서
+// 네이티브처럼 detail.x / detail.y 를 갖지 않아요.
+interface WebMouseEvent {
+  button?: number;
+  buttons?: number;
+  clientX?: number;
+  clientY?: number;
+  x?: number;
+  y?: number;
+}
+
+interface WebTouchEvent {
+  changedTouches?: Array<{ clientX?: number; clientY?: number }>;
+  touches?: Array<{ clientX?: number; clientY?: number }>;
+}
+
+function getMousePoint(e: WebMouseEvent): Point {
+  return { x: e.clientX ?? e.x ?? 0, y: e.clientY ?? e.y ?? 0 };
+}
+
+function getTouchPoint(e: BaseTouchEvent<Target>): Point {
+  if (!isWebPlatform) {
+    return { x: e.detail.x, y: e.detail.y };
+  }
+
+  const webEvent = e as unknown as WebTouchEvent;
+  const touch = webEvent.changedTouches?.[0] ?? webEvent.touches?.[0];
+  return { x: touch?.clientX ?? 0, y: touch?.clientY ?? 0 };
+}
+
 function resolveAnchors(initial?: InitialPosition): ResolvedAnchors {
   // top/left이 명시되면 그것이 anchor가 돼요. 둘 다 명시되면 top/left가 이겨요.
   const vertical: VerticalAxis = initial?.top !== undefined ? "top" : "bottom";
@@ -74,6 +109,9 @@ export function useDrag(onTap: () => void, options?: UseDragOptions) {
   const [x, setX] = useState(initX);
   const [y, setY] = useState(initY);
   const [phase, setPhase] = useState<"idle" | "dragging" | "releasing">("idle");
+  // web은 커서가 버튼 밖으로 나가면 mousemove/mouseup이 끊겨요.
+  // 누르고 있는 동안 화면 전체에 투명 오버레이를 깔아 이벤트를 계속 받아요.
+  const [pressed, setPressed] = useState(false);
   const [tempX, setTempX] = useState(initX);
   const [tempY, setTempY] = useState(initY);
 
@@ -85,19 +123,19 @@ export function useDrag(onTap: () => void, options?: UseDragOptions) {
   const xSign = anchors.horizontal === "right" ? -1 : 1;
   const ySign = anchors.vertical === "bottom" ? -1 : 1;
 
-  const handleTouchStart = (e: BaseTouchEvent<Target>) => {
+  const dragStart = (point: Point) => {
     startRef.current = {
-      x: e.detail.x,
-      y: e.detail.y,
+      x: point.x,
+      y: point.y,
       ax: x,
       ay: y,
     };
     draggingRef.current = false;
   };
 
-  const handleTouchMove = (e: BaseTouchEvent<Target>) => {
-    const dx = e.detail.x - startRef.current.x;
-    const dy = e.detail.y - startRef.current.y;
+  const dragMove = (point: Point) => {
+    const dx = point.x - startRef.current.x;
+    const dy = point.y - startRef.current.y;
 
     if (
       !draggingRef.current &&
@@ -115,7 +153,7 @@ export function useDrag(onTap: () => void, options?: UseDragOptions) {
     setTempY(startRef.current.ay + ySign * dy);
   };
 
-  const handleTouchEnd = () => {
+  const dragEnd = () => {
     if (draggingRef.current) {
       setX(tempX);
       setY(tempY);
@@ -132,9 +170,40 @@ export function useDrag(onTap: () => void, options?: UseDragOptions) {
         setPhase("idle");
         recentDragRef.current = false;
       }, 300);
-    } else {
+    } else if (!isWebPlatform) {
+      // web은 뒤이어 오는 click을 bindtap이 받아서 처리해요. 여기서 부르면 두 번 열려요.
       onTap();
     }
+  };
+
+  const handleTouchStart = (e: BaseTouchEvent<Target>) => {
+    dragStart(getTouchPoint(e));
+  };
+
+  const handleTouchMove = (e: BaseTouchEvent<Target>) => {
+    dragMove(getTouchPoint(e));
+  };
+
+  const handleMouseDown = (e: WebMouseEvent) => {
+    // 우클릭/가운데 클릭은 mouseup이 오지 않을 수 있어 주 버튼만 드래그로 다뤄요.
+    if (e.button !== undefined && e.button !== 0) return;
+
+    dragStart(getMousePoint(e));
+    setPressed(true);
+  };
+
+  const handleMouseUp = () => {
+    setPressed(false);
+    dragEnd();
+  };
+
+  const handleMouseMove = (e: WebMouseEvent) => {
+    // 창 밖에서 버튼을 뗀 경우 mouseup이 오지 않아서 눌림 상태로 남지 않도록 복구해요.
+    if (e.buttons === 0) {
+      handleMouseUp();
+      return;
+    }
+    dragMove(getMousePoint(e));
   };
 
   const handleWebTap = () => {
@@ -151,14 +220,29 @@ export function useDrag(onTap: () => void, options?: UseDragOptions) {
     [anchors.vertical]: `${currentY}px`,
   } as { top?: string; left?: string; right?: string; bottom?: string };
 
+  const mouseHandlers = {
+    catchmousedown: handleMouseDown,
+    catchmousemove: handleMouseMove,
+    catchmouseup: handleMouseUp,
+  };
+
   return {
     phase,
     positionStyle,
     handlers: {
       catchtouchstart: handleTouchStart,
       catchtouchmove: handleTouchMove,
-      catchtouchend: handleTouchEnd,
-      ...(isWebPlatform ? { bindtap: handleWebTap } : {}),
+      catchtouchend: dragEnd,
+      ...(isWebPlatform ? { bindtap: handleWebTap, ...mouseHandlers } : {}),
     },
+    // 누르고 있는 동안 화면 전체를 덮는 투명 오버레이용 핸들러예요.
+    // 커서가 버튼을 벗어나도 오버레이가 mousemove/mouseup을 대신 받아줘요.
+    dragOverlayHandlers:
+      isWebPlatform && (pressed || isDragging)
+        ? {
+            catchmousemove: handleMouseMove,
+            catchmouseup: handleMouseUp,
+          }
+        : null,
   };
 }


### PR DESCRIPTION
## 문제

브라우저에서 플로팅 버튼을 드래그로 옮길 수 없었어요. `useDrag`가 `catchtouchstart/move/end` 에만 의존하는데 데스크톱 브라우저는 터치 이벤트를 만들지 않아서, web에서만 붙는 `bindtap` 만 동작했어요. 탭으로 열리기는 해도 드래그는 아예 시작되지 않았어요.

파고들어 보니 하나 더 있었어요. Lynx web은 이벤트를 W3C 형태로 그대로 넘겨줘서 touch 이벤트에도 네이티브의 `detail.x/y` 가 없어요. 터치 브라우저에서도 드래그가 안 되던 상태였어요.

## 변경 내용

좌표 추출만 플랫폼별로 나누고 상태 머신은 하나로 공유해요. **네이티브 런타임 경로는 그대로예요** — 모든 분기가 `isWebPlatform` 뒤에 있어요.

- web에서 `catchmousedown/mousemove/mouseup` 을 추가 바인딩 (`bind*`/`catch*` 이벤트명은 그대로 `addEventListener` 로 내려가요)
- 커서가 버튼을 벗어나면 `mousemove`/`mouseup` 이 끊겨서 빠른 드래그가 전혀 안 먹었어요. 누르고 있는 동안만 전체 화면 투명 오버레이를 렌더해 이벤트를 계속 받아요. 워커엔 `document` 가 없고 Lynx 이벤트는 엘리먼트 단위라 `setPointerCapture` 대신 쓰는 방식이에요
- web touch는 `changedTouches[0].clientX/Y` 사용 (네이티브는 `detail.x/y` 그대로)
- 드래그 직후 `click` 으로 콘솔이 열리지 않도록 기존 `recentDrag` 가드를 마우스 경로에도 적용
- 주 버튼만 드래그로 다루고, 창 밖에서 뗀 경우는 `buttons === 0` 으로 복구해요
- reload 버튼은 web에서 `catchmousedown` no-op으로 드래그 시작을 막아요

## 검증

`npx rsbuild dev -c example/web/rsbuild.config.mjs` 로 띄운 web 셸에서 실제 브라우저로 확인했어요.

- [x] 드래그하면 놓은 위치로 이동·유지되고, 드래그로는 콘솔이 안 열려요
- [x] 짧은 클릭은 콘솔을 열어요
- [x] reload 버튼에서 시작한 드래그는 버튼을 안 움직이고, reload 클릭은 그대로 동작해요
- [x] 아래쪽 데모 버튼이 잘못 클릭되지 않고, 새 콘솔 에러도 없어요
- [x] `yarn check` / `yarn build` / `yarn build:example`(타입체크 포함) 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
