### PR TITLE
Example UI redesign

### DIFF
--- a/example/src/App.css
+++ b/example/src/App.css
@@ -1,6 +1,9 @@
+@import "./styles/theme.css";
+
 .app-container {
   width: 100%;
   height: 100%;
+  background-color: #ffffff;
 }
 
 .app-list {
@@ -8,75 +11,19 @@
   height: 100%;
 }
 
-.app-section {
+.app-hero {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 16px;
+  gap: 6px;
+  padding: 32px 20px 4px 20px;
 }
 
-.app-sectionTitle {
-  font-size: 16px;
-  font-weight: bold;
-  color: #2d3748;
-  margin-bottom: 4px;
+.app-listBottomSpace {
+  height: 120px;
 }
 
-.app-baseButton {
-  padding: 12px 16px;
-  border-radius: 8px;
+.app-debugPanel {
   display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.app-buttonText {
-  font-size: 14px;
-  font-weight: 500;
-  text-align: center;
-}
-
-.app-infoText {
-  font-size: 12px;
-  font-weight: 400;
-  color: #64748b;
-  white-space: pre-wrap;
-}
-
-.app-consoleButton {
-  background-color: #f7fafc;
-}
-.app-getButton {
-  background-color: #ebf8ff;
-}
-.app-postButton {
-  background-color: #f0fff4;
-}
-.app-patchButton {
-  background-color: #faf5ff;
-}
-.app-deleteButton {
-  background-color: #fff5f5;
-}
-.app-graphqlButton {
-  background-color: #fdf2f8;
-}
-
-.app-consoleButtonText {
-  color: #4a5568;
-}
-.app-getButtonText {
-  color: #3182ce;
-}
-.app-postButtonText {
-  color: #38a169;
-}
-.app-patchButtonText {
-  color: #805ad5;
-}
-.app-deleteButtonText {
-  color: #e53e3e;
-}
-.app-graphqlButtonText {
-  color: #db2777;
+  flex-direction: column;
+  padding: 4px 0;
 }

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,9 +1,14 @@
 import { lazy, Suspense } from '@lynx-js/react';
+import { ActionRow, ActionRowContent, Section } from './components';
+import { usePressFeedback } from './hooks/usePressFeedback';
 import './App.css';
 
 const LynxConsole = lazy(() => import('lynx-console'));
 
 const App = () => {
+  // main-thread 핸들러(worklet)는 컴포넌트 prop 으로 넘기면 깨져서, 이 줄만 <view> 를 직접 만들어요
+  const mainThreadRowPress = usePressFeedback('actionRow--pressed');
+
   const testConsoleLog = () => {
     console.log(
       'This is a log message',
@@ -130,135 +135,135 @@ const App = () => {
   return (
     <view className="app-container">
       <list className="app-list" scroll-orientation="vertical">
+        <list-item item-key="hero">
+          <view className="app-hero">
+            <text className="app-title">lynx-console</text>
+            <text className="app-subtitle">
+              아래 항목을 눌러 로그와 네트워크 요청을 만들고, 오른쪽 아래 플로팅
+              버튼으로 콘솔을 열어 확인해보세요.
+            </text>
+          </view>
+        </list-item>
+
         <list-item item-key="section-console">
-          <view className="app-section">
-            <text className="app-sectionTitle">Console Tests</text>
-            <view
+          <Section title="콘솔">
+            <ActionRow
+              label="Console Log"
+              caption="객체 · Map · Set 을 함께 출력해요"
+              meta="log"
               bindtap={testConsoleLog}
-              className="app-baseButton app-consoleButton"
-            >
-              <text className="app-buttonText app-consoleButtonText">
-                Test Console Log
-              </text>
-            </view>
-            <view
+            />
+            <ActionRow
+              label="CSS Console Log"
+              caption="서식 지정자(%c %s %d %o)를 렌더링해요"
+              meta="log"
               bindtap={testCssConsoleLog}
-              className="app-baseButton app-consoleButton"
-            >
-              <text className="app-buttonText app-consoleButtonText">
-                Test CSS Console Log
-              </text>
-            </view>
+            />
             <view
-              bindtap={() => {
-                throw new Error('Test Error');
-              }}
-              className="app-baseButton app-consoleButton"
+              className={`${mainThreadRowPress.className} actionRow`}
+              main-thread:bindtap={testConsoleLogInMainThread}
+              {...mainThreadRowPress.handlers}
             >
-              <text className="app-buttonText app-consoleButtonText">
-                Test throw error
-              </text>
+              <ActionRowContent
+                label="Console Log"
+                caption="메인 스레드에서 남기는 로그예요"
+                meta="main thread"
+              />
             </view>
-            <view
+            <ActionRow
+              label="Console Error"
+              caption="console.error 한 줄을 남겨요"
+              meta="error"
+              tone="red"
               bindtap={() => {
                 console.error('Test console error');
               }}
-              className="app-baseButton app-consoleButton"
-            >
-              <text className="app-buttonText app-consoleButtonText">
-                Test console error
-              </text>
-            </view>
-            <view
-              main-thread:bindtap={testConsoleLogInMainThread}
-              className="app-baseButton app-consoleButton"
-            >
-              <text className="app-buttonText app-consoleButtonText">
-                Test Console Log (Main Thread)
-              </text>
-            </view>
-          </view>
+            />
+            <ActionRow
+              label="Throw Error"
+              caption="처리되지 않은 예외를 던져요"
+              meta="error"
+              tone="red"
+              bindtap={() => {
+                throw new Error('Test Error');
+              }}
+            />
+          </Section>
         </list-item>
 
         <list-item item-key="section-track">
-          <view className="app-section">
-            <text className="app-sectionTitle">Filter Tab Tests</text>
-            <view
+          <Section title="필터 탭">
+            <ActionRow
+              label="screen_view"
+              caption="Track 탭에만 모이는 커스텀 로그예요"
+              meta="track"
+              tone="pink"
               bindtap={() => testTrackEvent('screen_view')}
-              className="app-baseButton app-consoleButton"
-            >
-              <text className="app-buttonText app-consoleButtonText">
-                Track screen_view
-              </text>
-            </view>
-            <view
+            />
+            <ActionRow
+              label="button_click"
+              caption="Track 탭에만 모이는 커스텀 로그예요"
+              meta="track"
+              tone="pink"
               bindtap={() => testTrackEvent('button_click')}
-              className="app-baseButton app-consoleButton"
-            >
-              <text className="app-buttonText app-consoleButtonText">
-                Track button_click
-              </text>
-            </view>
-          </view>
+            />
+          </Section>
         </list-item>
 
         <list-item item-key="section-network">
-          <view className="app-section">
-            <text className="app-sectionTitle">Network Tests</text>
-            <view
+          <Section title="네트워크">
+            <ActionRow
+              label="jsonplaceholder /posts/1"
+              caption="목록 한 건을 받아와요"
+              meta="GET"
+              tone="blue"
               bindtap={testGetRequest}
-              className="app-baseButton app-getButton"
-            >
-              <text className="app-buttonText app-getButtonText">
-                GET Request
-              </text>
-            </view>
-            <view
+            />
+            <ActionRow
+              label="jsonplaceholder /posts"
+              caption="새 글을 만들어요"
+              meta="POST"
+              tone="green"
               bindtap={testPostRequest}
-              className="app-baseButton app-postButton"
-            >
-              <text className="app-buttonText app-postButtonText">
-                POST Request
-              </text>
-            </view>
-            <view
+            />
+            <ActionRow
+              label="jsonplaceholder /posts/1"
+              caption="제목만 바꿔요"
+              meta="PATCH"
+              tone="purple"
               bindtap={testPatchRequest}
-              className="app-baseButton app-patchButton"
-            >
-              <text className="app-buttonText app-patchButtonText">
-                PATCH Request
-              </text>
-            </view>
-            <view
+            />
+            <ActionRow
+              label="jsonplaceholder /posts/1"
+              caption="한 건을 지워요"
+              meta="DELETE"
+              tone="red"
               bindtap={testDeleteRequest}
-              className="app-baseButton app-deleteButton"
-            >
-              <text className="app-buttonText app-deleteButtonText">
-                DELETE Request
-              </text>
-            </view>
-            <view
+            />
+            <ActionRow
+              label="graphql.org /graphql"
+              caption="graphql-response+json 응답이에요"
+              meta="GQL"
+              tone="pink"
               bindtap={testGraphqlRequest}
-              className="app-baseButton app-graphqlButton"
-            >
-              <text className="app-buttonText app-graphqlButtonText">
-                GraphQL Request
-              </text>
-            </view>
+            />
+          </Section>
+        </list-item>
+
+        <list-item item-key="section-list-header">
+          <view className="section">
+            <text className="section-title app-sectionTitle">스크롤 목록</text>
           </view>
         </list-item>
 
         {Array.from({ length: 20 }, (_, i) => (
           <list-item item-key={`item-${i}`} key={`item-${i}`}>
-            <view
+            <ActionRow
+              label={`List Item ${i + 1}`}
+              meta="log"
               bindtap={() => console.log(`Item ${i + 1} tapped`)}
-              className="app-baseButton app-consoleButton"
-              style={{ margin: '4px 16px' }}
-            >
-              <text className="app-buttonText app-consoleButtonText">
-                List Item {i + 1}
-              </text>
-            </view>
+            />
+            {i === 19 ? <view className="app-listBottomSpace" /> : null}
           </list-item>
         ))}
       </list>
@@ -279,24 +284,15 @@ const App = () => {
               key: 'debug',
               label: 'Debug',
               renderContent: () => (
-                <view
-                  style={{
-                    padding: '16px',
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: '8px',
-                  }}
-                >
-                  <view
+                <view className="app-debugPanel">
+                  <ActionRow
+                    label="Log globalProps"
+                    caption="lynx.__globalProps 를 출력해요"
+                    meta="log"
                     bindtap={() => {
                       console.log(lynx.__globalProps);
                     }}
-                    className="app-baseButton app-consoleButton"
-                  >
-                    <text className="app-buttonText app-consoleButtonText">
-                      Log globalProps
-                    </text>
-                  </view>
+                  />
                 </view>
               ),
             },

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -215,36 +215,31 @@ const App = () => {
             <ActionRow
               label="jsonplaceholder /posts/1"
               caption="목록 한 건을 받아와요"
-              meta="GET"
-              tone="blue"
+              method="GET"
               bindtap={testGetRequest}
             />
             <ActionRow
               label="jsonplaceholder /posts"
               caption="새 글을 만들어요"
-              meta="POST"
-              tone="green"
+              method="POST"
               bindtap={testPostRequest}
             />
             <ActionRow
               label="jsonplaceholder /posts/1"
               caption="제목만 바꿔요"
-              meta="PATCH"
-              tone="purple"
+              method="PATCH"
               bindtap={testPatchRequest}
             />
             <ActionRow
               label="jsonplaceholder /posts/1"
               caption="한 건을 지워요"
-              meta="DELETE"
-              tone="red"
+              method="DELETE"
               bindtap={testDeleteRequest}
             />
             <ActionRow
               label="graphql.org /graphql"
               caption="graphql-response+json 응답이에요"
-              meta="GQL"
-              tone="pink"
+              method="POST"
               bindtap={testGraphqlRequest}
             />
           </Section>

--- a/example/src/components/ActionRow.css
+++ b/example/src/components/ActionRow.css
@@ -1,0 +1,24 @@
+.actionRow {
+  flex-direction: row;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 20px;
+  /* 줄 사이 구분선이에요. 섹션 마지막 줄에서는 섹션 경계선 역할을 해요 */
+  border-bottom: 1px solid #f2f2f2;
+}
+
+.actionRow--pressed {
+  background-color: #f7f7f8;
+}
+
+.actionRow-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  flex-grow: 1;
+  flex-shrink: 1;
+}
+
+.actionRow-meta {
+  flex-shrink: 0;
+}

--- a/example/src/components/ActionRow.tsx
+++ b/example/src/components/ActionRow.tsx
@@ -1,13 +1,15 @@
 import { Pressable } from './Pressable';
-import { metaFg, type Tone } from './tone';
+import { metaFg, methodChip, type Tone } from './tone';
 import './ActionRow.css';
 
 interface ActionRowContentProps {
   label: string;
   caption?: string;
-  /** 오른쪽 끝에 붙는 짧은 보조 텍스트예요 (GET, main thread …). */
+  /** 오른쪽 끝에 붙는 짧은 보조 텍스트예요 (log, main thread …). */
   meta?: string;
   tone?: Tone;
+  /** HTTP 메서드예요. 콘솔 Network 탭과 같은 칩으로 그려요. */
+  method?: string;
 }
 
 /**
@@ -19,12 +21,18 @@ export const ActionRowContent = ({
   caption,
   meta,
   tone = 'neutral',
+  method,
 }: ActionRowContentProps) => (
   <>
     <view className="actionRow-body">
       <text className="app-label">{label}</text>
       {caption ? <text className="app-caption">{caption}</text> : null}
     </view>
+    {method ? (
+      <text className={`actionRow-meta app-methodChip ${methodChip(method)}`}>
+        {method}
+      </text>
+    ) : null}
     {meta ? (
       <text className={`actionRow-meta app-meta ${metaFg(tone)}`}>{meta}</text>
     ) : null}

--- a/example/src/components/ActionRow.tsx
+++ b/example/src/components/ActionRow.tsx
@@ -1,0 +1,47 @@
+import { Pressable } from './Pressable';
+import { metaFg, type Tone } from './tone';
+import './ActionRow.css';
+
+interface ActionRowContentProps {
+  label: string;
+  caption?: string;
+  /** 오른쪽 끝에 붙는 짧은 보조 텍스트예요 (GET, main thread …). */
+  meta?: string;
+  tone?: Tone;
+}
+
+/**
+ * 액션 한 줄의 내용이에요.
+ * 탭 영역을 직접 만들어야 할 때(main-thread 핸들러 등) 이것만 가져다 써요.
+ */
+export const ActionRowContent = ({
+  label,
+  caption,
+  meta,
+  tone = 'neutral',
+}: ActionRowContentProps) => (
+  <>
+    <view className="actionRow-body">
+      <text className="app-label">{label}</text>
+      {caption ? <text className="app-caption">{caption}</text> : null}
+    </view>
+    {meta ? (
+      <text className={`actionRow-meta app-meta ${metaFg(tone)}`}>{meta}</text>
+    ) : null}
+  </>
+);
+
+interface ActionRowProps extends ActionRowContentProps {
+  bindtap?: () => void;
+}
+
+/** 목록 안에 쌓아 쓰는 한 줄짜리 액션이에요. */
+export const ActionRow = ({ bindtap, ...content }: ActionRowProps) => (
+  <Pressable
+    className="actionRow"
+    pressedClassName="actionRow--pressed"
+    bindtap={bindtap}
+  >
+    <ActionRowContent {...content} />
+  </Pressable>
+);

--- a/example/src/components/Pressable.tsx
+++ b/example/src/components/Pressable.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from '@lynx-js/react';
+import { usePressFeedback } from '../hooks/usePressFeedback';
+
+interface PressableProps {
+  children: ReactNode;
+  className?: string;
+  /** 눌린 동안에만 붙는 클래스예요 (배경색 등). */
+  pressedClassName?: string;
+  bindtap?: () => void;
+}
+
+/** 누르면 살짝 줄어드는 탭 영역이에요. */
+export const Pressable = ({
+  children,
+  className = '',
+  pressedClassName = '',
+  bindtap,
+}: PressableProps) => {
+  const { className: pressClassName, handlers } =
+    usePressFeedback(pressedClassName);
+
+  return (
+    <view
+      className={`${pressClassName} ${className}`}
+      bindtap={bindtap}
+      {...handlers}
+    >
+      {children}
+    </view>
+  );
+};

--- a/example/src/components/Section.css
+++ b/example/src/components/Section.css
@@ -1,0 +1,14 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  padding-top: 24px;
+}
+
+.section-title {
+  padding: 0 20px 6px 20px;
+}
+
+.section-rows {
+  display: flex;
+  flex-direction: column;
+}

--- a/example/src/components/Section.tsx
+++ b/example/src/components/Section.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from '@lynx-js/react';
+import './Section.css';
+
+interface SectionProps {
+  title: string;
+  children: ReactNode;
+}
+
+/** 제목 아래에 액션 줄들을 쌓아요. */
+export const Section = ({ title, children }: SectionProps) => (
+  <view className="section">
+    <text className="section-title app-sectionTitle">{title}</text>
+    <view className="section-rows">{children}</view>
+  </view>
+);

--- a/example/src/components/index.ts
+++ b/example/src/components/index.ts
@@ -1,0 +1,4 @@
+export { ActionRow, ActionRowContent } from './ActionRow';
+export { Pressable } from './Pressable';
+export { Section } from './Section';
+export type { Tone } from './tone';

--- a/example/src/components/tone.ts
+++ b/example/src/components/tone.ts
@@ -10,3 +10,13 @@ export type Tone =
 
 export const metaFg = (tone: Tone) =>
   tone === 'neutral' ? '' : `app-metaFg-${tone}`;
+
+// 콘솔 Network 탭과 같은 메서드 칩 색이에요.
+const METHOD_CLASSES = ['get', 'post', 'put', 'patch', 'delete'];
+
+export const methodChip = (method: string) => {
+  const key = method.toLowerCase();
+  return METHOD_CLASSES.includes(key)
+    ? `app-method-${key}`
+    : 'app-method-default';
+};

--- a/example/src/components/tone.ts
+++ b/example/src/components/tone.ts
@@ -1,0 +1,12 @@
+// 오른쪽 메타 텍스트에만 쓰는 강조색이에요. theme.css 의 .app-metaFg-* 와 짝이에요.
+export type Tone =
+  | 'neutral'
+  | 'blue'
+  | 'green'
+  | 'purple'
+  | 'red'
+  | 'pink'
+  | 'orange';
+
+export const metaFg = (tone: Tone) =>
+  tone === 'neutral' ? '' : `app-metaFg-${tone}`;

--- a/example/src/hooks/usePressFeedback.ts
+++ b/example/src/hooks/usePressFeedback.ts
@@ -1,0 +1,38 @@
+import { useState } from '@lynx-js/react';
+import { isWebPlatform } from '../utils/isWebPlatform';
+import '../styles/press.css';
+
+/**
+ * 누르는 동안 살짝 줄어드는 피드백을 만들어요.
+ * 반환한 className 과 handlers 를 탭 영역이 될 <view> 에 그대로 펼쳐 쓰면 돼요.
+ *
+ * main-thread 핸들러(worklet)는 컴포넌트 prop 으로 넘기면 깨져서,
+ * 그런 경우엔 이 훅으로 <view> 를 직접 만들어요.
+ */
+export const usePressFeedback = (pressedClassName = '') => {
+  const [pressed, setPressed] = useState(false);
+
+  const press = () => setPressed(true);
+  const release = () => setPressed(false);
+
+  // 웹에서는 터치 이벤트가 오지 않아 마우스 이벤트로 같은 상태를 만들어요.
+  const webHandlers = isWebPlatform
+    ? {
+        bindmousedown: press,
+        bindmouseup: release,
+        bindmouseleave: release,
+      }
+    : {};
+
+  return {
+    className: pressed
+      ? `pressable pressable--pressed ${pressedClassName}`
+      : 'pressable',
+    handlers: {
+      bindtouchstart: press,
+      bindtouchend: release,
+      bindtouchcancel: release,
+      ...webHandlers,
+    },
+  };
+};

--- a/example/src/styles/press.css
+++ b/example/src/styles/press.css
@@ -1,0 +1,9 @@
+/* 누름 피드백 (usePressFeedback) 전용 스타일이에요. */
+.pressable {
+  display: flex;
+  transition: transform 120ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+.pressable--pressed {
+  transform: scale(0.98);
+}

--- a/example/src/styles/theme.css
+++ b/example/src/styles/theme.css
@@ -1,0 +1,61 @@
+/* 화면 전체에서 재사용하는 텍스트 · 색이에요. 회색 스케일은 Seed 팔레트를 따라가요. */
+
+.app-title {
+  font-size: 24px;
+  line-height: 32px;
+  font-weight: 700;
+  color: #212124;
+}
+
+.app-subtitle {
+  font-size: 14px;
+  line-height: 20px;
+  color: #909090;
+}
+
+.app-sectionTitle {
+  font-size: 13px;
+  line-height: 18px;
+  font-weight: 700;
+  color: #909090;
+}
+
+.app-label {
+  font-size: 15px;
+  line-height: 22px;
+  font-weight: 500;
+  color: #212124;
+}
+
+.app-caption {
+  font-size: 13px;
+  line-height: 18px;
+  color: #909090;
+}
+
+.app-meta {
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 600;
+  color: #adadad;
+}
+
+/* 메타 텍스트 강조색 (HTTP 메서드 등) */
+.app-metaFg-blue {
+  color: #1b6ef3;
+}
+.app-metaFg-green {
+  color: #00a05b;
+}
+.app-metaFg-purple {
+  color: #7048e8;
+}
+.app-metaFg-red {
+  color: #e5343d;
+}
+.app-metaFg-pink {
+  color: #d6336c;
+}
+.app-metaFg-orange {
+  color: #ff6f0f;
+}

--- a/example/src/styles/theme.css
+++ b/example/src/styles/theme.css
@@ -59,3 +59,38 @@
 .app-metaFg-orange {
   color: #ff6f0f;
 }
+
+/* 콘솔 Network 탭의 메서드 칩과 같은 모양 · 색이에요
+   (package/src/styles/theme.ts 라이트 팔레트) */
+.app-methodChip {
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 700;
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+.app-method-get {
+  color: #5e98fe;
+  background-color: #eff6ff;
+}
+.app-method-post {
+  color: #10ab7d;
+  background-color: #edfaf6;
+}
+.app-method-put {
+  color: #c49725;
+  background-color: #fff7de;
+}
+.app-method-patch {
+  color: #9f84fb;
+  background-color: #f5f3fe;
+}
+.app-method-delete {
+  color: #fc6a66;
+  background-color: #fdf0f0;
+}
+.app-method-default {
+  color: #6b6b6b;
+  background-color: #f4f4f4;
+}

--- a/example/src/utils/isWebPlatform.ts
+++ b/example/src/utils/isWebPlatform.ts
@@ -1,0 +1,4 @@
+// 웹(<lynx-view>) 에서는 터치 이벤트 대신 마우스 이벤트가 와요.
+export const isWebPlatform: boolean =
+  typeof SystemInfo !== 'undefined' &&
+  (SystemInfo.platform as string) === 'web';


### PR DESCRIPTION
버튼만 세로로 나열하던 예제 앱 화면을 목록형으로 다시 그리고, 반복되는 스타일을 재사용할 수 있게 나눴어요.

## 화면

흰 배경에 회색 스케일만 쓰는 목록 UI 예요. 섹션 제목(콘솔 / 필터 탭 / 네트워크 / 스크롤 목록) 아래에 줄이 쌓이고, 각 줄은 제목 + 설명 + 오른쪽 메타(`log`, `main thread`, `error`, `track`)로 구성돼요.

네트워크 줄의 GET · POST · PATCH · DELETE 는 콘솔 Network 탭이 그리는 것과 같은 모양 · 색이에요 (`package/src/styles/theme.ts` 라이트 팔레트를 그대로 가져왔어요). GraphQL 줄도 실제 요청대로 POST 로 표시해요.

## 누름 피드백

줄을 누르면 `scale(0.98)` 로 살짝 줄어들고 배경이 `#f7f7f8` 로 바뀌어요 (120ms). 네이티브는 터치 이벤트, 웹은 마우스 이벤트로 같은 상태를 만들어요.
